### PR TITLE
Feat: badges and participants management

### DIFF
--- a/lib/lanpartyseating/logic/badge_scan_logs_logic.ex
+++ b/lib/lanpartyseating/logic/badge_scan_logs_logic.ex
@@ -1,0 +1,11 @@
+defmodule Lanpartyseating.BadgeScanLogsLogic do
+  import Ecto.Query
+  alias Lanpartyseating.BadgeScanLogs, as: BadgeScanLogs
+  alias Lanpartyseating.Repo, as: Repo
+
+  def get_all_participants do
+    BadgeScanLogs
+    |> Repo.all()
+  end
+
+end

--- a/lib/lanpartyseating/logic/reservation_logic.ex
+++ b/lib/lanpartyseating/logic/reservation_logic.ex
@@ -1,11 +1,11 @@
 defmodule Lanpartyseating.ReservationLogic do
   import Ecto.Query
-  alias Lanpartyseating.Station, as: Station
   alias Lanpartyseating.Reservation, as: Reservation
   alias Lanpartyseating.Repo, as: Repo
   alias Lanpartyseating.StationLogic, as: StationLogic
 
   def create_reservation(seat_number, duration, badge_number) do
+    IO.inspect(label: "create_reservation called")
 
     if badge_number == "" do
       %{type: "error", message: "Please fill all the fields" }
@@ -30,6 +30,7 @@ defmodule Lanpartyseating.ReservationLogic do
         # %{type: "success", message: "Please fill all the fields", response: Repo.get(Reservation, updated.id)}
 
       else
+        IO.inspect(label: "is not creatable")
         %{type: "error", message: "Unavailable"}
       end
     end

--- a/lib/lanpartyseating/logic/seating_logic.ex
+++ b/lib/lanpartyseating/logic/seating_logic.ex
@@ -1,6 +1,7 @@
 defmodule Lanpartyseating.SeatingLogic do
   alias Lanpartyseating.BadgeScanLogs, as: BadgeScanLogs
   alias Lanpartyseating.LastAssignedSeat, as: LastAssignedSeat
+  alias Lanpartyseating.SettingsLogic, as: SettingsLogic
   alias Lanpartyseating.Repo, as: Repo
 
   def register_seat(badge_number) do
@@ -12,8 +13,13 @@ defmodule Lanpartyseating.SeatingLogic do
       las = LastAssignedSeat
       |> Repo.one()
 
-      # Get the next available seat
-      next_seat = las.last_assigned_seat + 1
+      settings = SettingsLogic.get_settings()
+
+      # Get the next available seat. Warp around,
+      # TODO: Logic should be more complicated, we have to jump above unavailable seats to get to the next available
+      # Seats are not reservable only if no available seat is left. Handle this via an error.
+      # The user must be informed that no seat is available.
+      next_seat = rem(las.last_assigned_seat + 1, settings.columns * settings.rows)
 
       # Log badge scans, seat ID is set to participant
       expiry_time = DateTime.truncate(DateTime.utc_now() |> DateTime.add(45, :minute), :second)

--- a/lib/lanpartyseating_web/live/badges_live.ex
+++ b/lib/lanpartyseating_web/live/badges_live.ex
@@ -1,6 +1,7 @@
 defmodule LanpartyseatingWeb.BadgesLive do
   use LanpartyseatingWeb, :live_view
   alias Lanpartyseating.SeatingLogic, as: SeatingLogic
+  alias Lanpartyseating.ReservationLogic, as: ReservationLogic
 
   def mount(_params, _session, socket) do
     socket =
@@ -18,20 +19,20 @@ defmodule LanpartyseatingWeb.BadgesLive do
         IO.inspect(label: "******** SeatingLogic.register_seat called")
         IO.inspect(label: "******** assigned id: " <> assigned_station_id)
 
+        # TODO: Handle case where create_reservation failed. It's possible that the function
+        # fails to assign the requested seat.
+        ReservationLogic.create_reservation(String.to_integer(assigned_station_id), 45, badge_number)
+
+        ## TODO: Display the ID of the reserved seat, all station have a username and password that relates to their ID
+        ## The ID is the one of the next available station. People who come in group should scan their
+        ## badge one after another if they want to be togheter.
+
         "Your assigned seat is: " <>
           assigned_station_id <>
           " (make this message disappear after 5 seconds with a nice fade out)"
       else
         "Empty badge number submitted"
       end
-
-    # ??? is this
-    # stations = StationLogic.get_all_stations()
-    # broadcast_stations(stations)
-
-    ## TODO: Display the ID of the reserved seat, all station have a username and password that relates to their ID
-    ## The ID is the one of the next available station. People who come in group should scan their
-    ## badge one after another if they want to be togheter.
 
     {:noreply, assign(socket, :message, message)}
   end

--- a/lib/lanpartyseating_web/live/badges_live.ex
+++ b/lib/lanpartyseating_web/live/badges_live.ex
@@ -23,6 +23,8 @@ defmodule LanpartyseatingWeb.BadgesLive do
         # fails to assign the requested seat.
         ReservationLogic.create_reservation(String.to_integer(assigned_station_id), 45, badge_number)
 
+        ## TODO: Create username and password in AD
+
         ## TODO: Display the ID of the reserved seat, all station have a username and password that relates to their ID
         ## The ID is the one of the next available station. People who come in group should scan their
         ## badge one after another if they want to be togheter.

--- a/lib/lanpartyseating_web/live/participants_live.ex
+++ b/lib/lanpartyseating_web/live/participants_live.ex
@@ -1,7 +1,15 @@
 defmodule LanpartyseatingWeb.ParticipantsLive do
   use LanpartyseatingWeb, :live_view
+  alias Lanpartyseating.BadgeScanLogsLogic, as: BadgeScanLogsLogic
 
   def mount(_params, _session, socket) do
+    participants = BadgeScanLogsLogic.get_all_participants()
+
+    socket =
+      socket
+      |> assign(:participants, Enum.reverse(participants))
+      |> assign(:participantsCount, length(participants))
+
     {:ok, socket}
   end
 
@@ -11,39 +19,43 @@ defmodule LanpartyseatingWeb.ParticipantsLive do
       <h1 style="font-size:30px">Seats</h1>
 
       <table>
-        <tr>
+      <tr>
           <th>badge id</th>
           <!-- badge uid -->
           <th>last scan</th>
           <!-- scan date that triggered the creation of the user in the AD -->
+
           <th>minutes left</th>
           <!-- minutes left until the user can't login or is logged off -->
+
+          <th>expiry</th>
+
+          <th>seat number</th>
+
           <th>deactivated</th>
           <!-- a boolean that's true once the user has been successfully deleted from the AD -->
           <th>username</th>
           <!-- username as the temporary login credential -->
         </tr>
+      <%= for participant <- @participants do %>
         <tr>
-          <td>00193</td>
-          <td>May 6 2023, 17:43</td>
-          <td>32</td>
-          <td>no</td>
-          <td>fish 🐟</td>
+          <th><%= participant.badge_number %></th>
+          <!-- badge uid -->
+          <th><%= participant.date_scanned %></th>
+          <!-- scan date that triggered the creation of the user in the AD -->
+          <th>?</th>
+          <!-- minutes left until the user can't login or is logged off -->
+
+          <th><%= participant.session_expiry %></th>
+
+          <th><%= participant.assigned_station_number %></th>
+
+          <th>?</th>
+          <!-- a boolean that's true once the user has been successfully deleted from the AD -->
+          <th>?</th>
+          <!-- username as the temporary login credential -->
         </tr>
-        <tr>
-          <td>04918</td>
-          <td>May 6 2023, 14:43</td>
-          <td>13</td>
-          <td>no</td>
-          <td>bee 🐝</td>
-        </tr>
-        <tr>
-          <td>03112</td>
-          <td>May 6 2023, 13:43</td>
-          <td>0</td>
-          <td>yes</td>
-          <td>sunflower 🌻</td>
-        </tr>
+        <% end %>
       </table>
     </div>
     """


### PR DESCRIPTION
Features implemented in this PR: 

* submitting a badge in the _Scan your badge_ page creates a new reserved station that can be seen in the rest of the app
* you can no longer reserve a seat at a number so high that it doesn't exist in the LAN
* the participants page now updates and shows a history of the badges that were scanned

Misc:

* "todos" were added for stuff left to be done