### PR TITLE
Update mix deps hash

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ let
   mixFodDeps = beamPackages.fetchMixDeps {
     pname = "${pname}-deps";
     inherit src version;
-    hash = "sha256-kOpNtvMhANcw9l1gQLXOfBdqEst9NMMhILlLzBXKJkI=";
+    hash = "sha256-cX5QFOH8kqxwTk5OwALHutyMwpiMzsadTCW+ZAqwajU=";
   };
 
   yarnDeps = mkYarnModules {


### PR DESCRIPTION
I forgot to update the mix deps hash in `default.nix` when I updated the deps for opentelemetry, causing the old cached deps to be used instead.