### PR TITLE
Feat/working reservation

### DIFF
--- a/lib/lanpartyseating/logic/reservation_logic.ex
+++ b/lib/lanpartyseating/logic/reservation_logic.ex
@@ -13,6 +13,10 @@ defmodule Lanpartyseating.ReservationLogic do
 
       station = StationLogic.get_station(seat_number)
 
+      if station == nil do
+        IO.inspect("In function 'create_reservation', 'get_station' returned nil. This will crash.")
+      end
+
       isCreatable = case StationLogic.get_station_status(station).status do
         :occupied       -> false
         :closed         -> false

--- a/lib/lanpartyseating/logic/seating_logic.ex
+++ b/lib/lanpartyseating/logic/seating_logic.ex
@@ -2,6 +2,7 @@ defmodule Lanpartyseating.SeatingLogic do
   alias Lanpartyseating.BadgeScanLogs, as: BadgeScanLogs
   alias Lanpartyseating.LastAssignedSeat, as: LastAssignedSeat
   alias Lanpartyseating.SettingsLogic, as: SettingsLogic
+  alias Lanpartyseating.StationLogic, as: StationLogic
   alias Lanpartyseating.Repo, as: Repo
 
   def register_seat(badge_number) do
@@ -20,6 +21,19 @@ defmodule Lanpartyseating.SeatingLogic do
       # Seats are not reservable only if no available seat is left. Handle this via an error.
       # The user must be informed that no seat is available.
       next_seat = rem(las.last_assigned_seat + 1, settings.columns * settings.rows)
+
+      stations = StationLogic.get_all_stations()
+
+      # Find the first result matching this condition
+      # The stations collection is split in half and we swap the end with the start so that
+      # we iterate on the last part first. This is so we search from the current index.
+      result = Enum.find(Enum.drop(stations, next_seat - 1) ++ Enum.take(stations, next_seat - 1), fn element ->
+        element.reservation == nil
+      end)
+
+      ## TODO: CHECK IF result is NIL
+      ## NIL means all stations are unavailable
+      next_seat = result.station.station_number
 
       # Log badge scans, seat ID is set to participant
       expiry_time = DateTime.truncate(DateTime.utc_now() |> DateTime.add(45, :minute), :second)

--- a/lib/lanpartyseating/logic/seating_logic.ex
+++ b/lib/lanpartyseating/logic/seating_logic.ex
@@ -3,6 +3,7 @@ defmodule Lanpartyseating.SeatingLogic do
   alias Lanpartyseating.LastAssignedSeat, as: LastAssignedSeat
   alias Lanpartyseating.SettingsLogic, as: SettingsLogic
   alias Lanpartyseating.StationLogic, as: StationLogic
+  alias Lanpartyseating.Station, as: Station
   alias Lanpartyseating.Repo, as: Repo
 
   def register_seat(badge_number) do
@@ -14,61 +15,58 @@ defmodule Lanpartyseating.SeatingLogic do
       las = LastAssignedSeat
       |> Repo.one()
 
+      # Warp around the first seat we look from when we reach the maximum number of seats
       settings = SettingsLogic.get_settings()
+      next_seat = rem(las.last_assigned_seat, settings.columns * settings.rows) + 1
 
-      # Get the next available seat. Warp around,
-      # TODO: Logic should be more complicated, we have to jump above unavailable seats to get to the next available
-      # Seats are not reservable only if no available seat is left. Handle this via an error.
-      # The user must be informed that no seat is available.
-      next_seat = rem(las.last_assigned_seat + 1, settings.columns * settings.rows)
-
-      stations = StationLogic.get_all_stations()
+      stations = StationLogic.get_all_stations_sorted_by_number()
 
       # Find the first result matching this condition
       # The stations collection is split in half and we swap the end with the start so that
-      # we iterate on the last part first. This is so we search from the current index.
-      result = Enum.find(Enum.drop(stations, next_seat - 1) ++ Enum.take(stations, next_seat - 1), fn element ->
-        element.reservation == nil
-      end)
+      # we iterate on the last part first. This is so we search from the current index, but we still search all the stations.
+      case Enum.find(Enum.drop(stations, next_seat - 1) ++ Enum.take(stations, next_seat - 1), fn element ->
+        element.reservation == nil and !element.station.is_closed and length(element.station.tournament_reservations) == 0
+      end) do
+        nil -> nil
 
-      ## TODO: CHECK IF result is NIL
-      ## NIL means all stations are unavailable
-      next_seat = result.station.station_number
+        result -> next_seat = result.station.station_number
 
-      # Log badge scans, seat ID is set to participant
-      expiry_time = DateTime.truncate(DateTime.utc_now() |> DateTime.add(45, :minute), :second)
+        # Log badge scans, seat ID is set to participant
+        expiry_time = DateTime.truncate(DateTime.utc_now() |> DateTime.add(45, :minute), :second)
 
-      # --> badge number = his bage number
-      # --> date scanned = time at which the request was created
-      # --> session expiry = date scanned + 45 minutes
-      # --> assigned station number = ID of the sation where the participant will be playing
-      # --> was removed from AD: false until expiration
-      # --> was cancelled: false unless sucessfully cancelled by a lan admin
-      # --> date cancelled: logs the date when the cancel request was completed
-      case Repo.insert(%BadgeScanLogs{badge_number: badge_number,
-                                 date_scanned: DateTime.truncate(DateTime.utc_now(), :second),
-                                 session_expiry: expiry_time,
-                                 assigned_station_number: next_seat,
-                                 was_removed_from_ad: false,
-                                 was_cancelled: false,
-                                 date_cancelled: nil
-                                 }) do
-                                  {:ok, result} -> result
-                                  {:error, error} -> error
-                                 end
+        # --> badge number = his bage number
+        # --> date scanned = time at which the request was created
+        # --> session expiry = date scanned + 45 minutes
+        # --> assigned station number = ID of the sation where the participant will be playing
+        # --> was removed from AD: false until expiration
+        # --> was cancelled: false unless sucessfully cancelled by a lan admin
+        # --> date cancelled: logs the date when the cancel request was completed
+        case Repo.insert(%BadgeScanLogs{badge_number: badge_number,
+                                  date_scanned: DateTime.truncate(DateTime.utc_now(), :second),
+                                  session_expiry: expiry_time,
+                                  assigned_station_number: next_seat,
+                                  was_removed_from_ad: false,
+                                  was_cancelled: false,
+                                  date_cancelled: nil
+                                  }) do
+                                    {:ok, result} -> result
+                                    {:error, error} -> error
+                                  end
 
-      # The seat is registered to participant. Update the last reserved seat in DB.
-      las = Ecto.Changeset.change las, last_assigned_seat: next_seat, last_assigned_seat_date: DateTime.truncate(DateTime.utc_now(), :second)
-      case Repo.update las do
-        {:ok, result} -> result
-        {:error, error} -> error
+        # The seat is registered to participant. Update the last reserved seat in DB.
+        las = Ecto.Changeset.change las, last_assigned_seat: next_seat, last_assigned_seat_date: DateTime.truncate(DateTime.utc_now(), :second)
+        case Repo.update las do
+          {:ok, result} -> result
+          {:error, error} -> error
+        end
+
+        # Return seat ID to be displayed to the participant
+        next_seat
+
       end
-
-      # Return seat ID to be displayed to the participant
-      next_seat
     end
 
-    to_string(number)
+    number
   end
 
   def cancel_seat(seat_id, reason) do

--- a/lib/lanpartyseating/logic/settings_logic.ex
+++ b/lib/lanpartyseating/logic/settings_logic.ex
@@ -1,6 +1,7 @@
 defmodule Lanpartyseating.SettingsLogic do
   import Ecto.Query
   alias Lanpartyseating.Setting, as: Setting
+  alias Lanpartyseating.LastAssignedSeat, as: LastAssignedSeat
   alias Lanpartyseating.Repo, as: Repo
 
   def get_settings do
@@ -10,9 +11,18 @@ defmodule Lanpartyseating.SettingsLogic do
   end
 
   def save_settings(rows, columns, row_padding, column_padding, is_diagonally_mirrored, horizontal_trailing, vertical_trailing) do
+    las = LastAssignedSeat
+    |> Repo.one()
+
     settings = Setting
     |> last(:inserted_at)
     |> Repo.one()
+
+    las = Ecto.Changeset.change las, last_assigned_seat: 0, last_assigned_seat_date: DateTime.truncate(DateTime.utc_now(), :second)
+    case Repo.update las do
+      {:ok, result} -> result
+      {:error, error} -> error
+    end
 
     settings = Ecto.Changeset.change settings, rows: rows, columns: columns, row_padding: row_padding,
       column_padding: column_padding, is_diagonally_mirrored: is_diagonally_mirrored,

--- a/lib/lanpartyseating/logic/station_logic.ex
+++ b/lib/lanpartyseating/logic/station_logic.ex
@@ -22,6 +22,20 @@ defmodule Lanpartyseating.StationLogic do
     Enum.map(stations, fn station -> Map.merge(%{station: station}, get_station_status(station)) end)
   end
 
+  def get_all_stations_sorted_by_number do
+    now = DateTime.truncate(DateTime.utc_now(), :second)
+    stations =
+      from(s in Station,
+        order_by: [asc: s.station_number],
+        left_join: r in assoc(s, :reservations),
+        left_join: tr in assoc(s, :tournament_reservations),
+        left_join: t in assoc(tr, :tournament),
+        where: is_nil(s.deleted_at),
+        preload: [reservations: r, tournament_reservations: {tr, tournament: t}]
+      ) |> Repo.all()
+    Enum.map(stations, fn station -> Map.merge(%{station: station}, get_station_status(station)) end)
+  end
+
   def get_station(station_number) do
     from(s in Station,
       order_by: [asc: s.id],

--- a/lib/lanpartyseating_web/live/badges_live.ex
+++ b/lib/lanpartyseating_web/live/badges_live.ex
@@ -14,24 +14,22 @@ defmodule LanpartyseatingWeb.BadgesLive do
   def handle_event("submit_reservation", %{"badge_number" => badge_number}, socket) do
     message =
       if String.length(badge_number) > 0 do
-        IO.inspect(label: "******** submit_reservation entered")
-        assigned_station_id = SeatingLogic.register_seat(badge_number)
-        IO.inspect(label: "******** SeatingLogic.register_seat called")
-        IO.inspect(label: "******** assigned id: " <> assigned_station_id)
+        case SeatingLogic.register_seat(badge_number) do
+          nil -> "No seat available. Please wait for a seat to be freed and scan your badge again."
+          number -> number
+          # TODO: Handle case where create_reservation failed. It's possible that the function
+          # fails to assign the requested seat.
 
-        # TODO: Handle case where create_reservation failed. It's possible that the function
-        # fails to assign the requested seat.
-        ReservationLogic.create_reservation(String.to_integer(assigned_station_id), 45, badge_number)
+          ReservationLogic.create_reservation(number, 45, badge_number)
 
-        ## TODO: Create username and password in AD
+          ## TODO: Create username and password in AD
 
-        ## TODO: Display the ID of the reserved seat, all station have a username and password that relates to their ID
-        ## The ID is the one of the next available station. People who come in group should scan their
-        ## badge one after another if they want to be togheter.
+          ## TODO: Display the ID of the reserved seat, all station have a username and password that relates to their ID
+          ## The ID is the one of the next available station. People who come in group should scan their
+          ## badge one after another if they want to be togheter.
 
-        "Your assigned seat is: " <>
-          assigned_station_id <>
-          " (make this message disappear after 5 seconds with a nice fade out)"
+          "Your assigned seat is: " <> to_string(number) <> " (make this message disappear after 5 seconds with a nice fade out)"
+        end
       else
         "Empty badge number submitted"
       end

--- a/lib/lanpartyseating_web/live/participants_live.ex
+++ b/lib/lanpartyseating_web/live/participants_live.ex
@@ -43,7 +43,11 @@ defmodule LanpartyseatingWeb.ParticipantsLive do
           <!-- badge uid -->
           <th><%= participant.date_scanned %></th>
           <!-- scan date that triggered the creation of the user in the AD -->
-          <th>?</th>
+
+          <th><%=case DateTime.diff(participant.session_expiry, DateTime.utc_now(), :minute) do
+            x when x < 0 -> 0
+            x -> x
+          end %></th>
           <!-- minutes left until the user can't login or is logged off -->
 
           <th><%= participant.session_expiry %></th>

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -81,7 +81,7 @@ Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
 
 # Create only data required in this table: The last assigned seat ID.
 Lanpartyseating.Repo.insert!(%Lanpartyseating.LastAssignedSeat{
-  last_assigned_seat: -1,
+  last_assigned_seat: 0,
   last_assigned_seat_date: ~U[2022-08-05 15:30:00Z]
 })
 


### PR DESCRIPTION
Implement reservations from the badge scanning page

Implementation is complete:

* Search for the next available station, skip unavailable ones, and warp around to the start when the end of the stations arrays is reached
* An error message is displayed when the reservation fails (e.g. all stations are busy)

TODO:
* Better error handling