### PR TITLE
Implement background tasks and more

### DIFF
--- a/lib/lanpartyseating/application.ex
+++ b/lib/lanpartyseating/application.ex
@@ -17,9 +17,11 @@ defmodule Lanpartyseating.Application do
       # Start the PubSub system
       {Phoenix.PubSub, [name: Lanpartyseating.PubSub, adapter: Phoenix.PubSub.PG2]},
       # Start the Endpoint (http/https)
-      LanpartyseatingWeb.Endpoint
+      LanpartyseatingWeb.Endpoint,
       # Start a worker by calling: Lanpartyseating.Worker.start_link(arg)
       # {Lanpartyseating.Worker, arg}
+      {Task.Supervisor, name: Lanpartyseating.ExpirationTaskSupervisor},
+      Lanpartyseating.ExpirationKickstarter,
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/lanpartyseating/logic/station_logic.ex
+++ b/lib/lanpartyseating/logic/station_logic.ex
@@ -3,6 +3,8 @@ defmodule Lanpartyseating.StationLogic do
   use Timex
   alias Lanpartyseating.Reservation, as: Reservation
   alias Lanpartyseating.Station, as: Station
+  alias Lanpartyseating.Tournament, as: Tournament
+  alias Lanpartyseating.TournamentReservation, as: TournamentReservation
   alias Lanpartyseating.Repo, as: Repo
 
   def number_stations do
@@ -10,20 +12,29 @@ defmodule Lanpartyseating.StationLogic do
   end
 
   def get_all_stations do
+    now = DateTime.truncate(DateTime.utc_now(), :second)
+
     stations =
       from(s in Station,
         order_by: [asc: s.id],
-        left_join: r in assoc(s, :reservations),
-        left_join: tr in assoc(s, :tournament_reservations),
-        left_join: t in assoc(tr, :tournament),
         where: is_nil(s.deleted_at),
         preload: [
           reservations:
             ^from(
               r in Reservation,
+              where: r.start_date < ^now,
+              where: r.end_date > ^now,
+              where: is_nil(r.deleted_at),
               order_by: [desc: r.inserted_at]
             ),
-          tournament_reservations: {tr, tournament: t}
+          tournament_reservations:
+            ^from(tr in TournamentReservation,
+              join: t in assoc(tr, :tournament),
+              where: t.start_date < ^now,
+              where: t.end_date > ^now,
+              where: is_nil(t.deleted_at),
+              preload: [tournament: t]
+            )
         ]
       )
       |> Repo.all()
@@ -34,20 +45,29 @@ defmodule Lanpartyseating.StationLogic do
   end
 
   def get_all_stations_sorted_by_number do
+    now = DateTime.truncate(DateTime.utc_now(), :second)
+
     stations =
       from(s in Station,
         order_by: [asc: s.station_number],
-        left_join: r in assoc(s, :reservations),
-        left_join: tr in assoc(s, :tournament_reservations),
-        left_join: t in assoc(tr, :tournament),
         where: is_nil(s.deleted_at),
         preload: [
           reservations:
             ^from(
               r in Reservation,
+              where: r.start_date < ^now,
+              where: r.end_date > ^now,
+              where: is_nil(r.deleted_at),
               order_by: [desc: r.inserted_at]
             ),
-          tournament_reservations: {tr, tournament: t}
+          tournament_reservations:
+            ^from(tr in TournamentReservation,
+              join: t in assoc(tr, :tournament),
+              where: t.start_date < ^now,
+              where: t.end_date > ^now,
+              where: is_nil(t.deleted_at),
+              preload: [tournament: t]
+            )
         ]
       )
       |> Repo.all()
@@ -58,20 +78,29 @@ defmodule Lanpartyseating.StationLogic do
   end
 
   def get_station(station_number) do
+    now = DateTime.truncate(DateTime.utc_now(), :second)
+
     from(s in Station,
       order_by: [asc: s.id],
-      left_join: r in assoc(s, :reservations),
-      left_join: tr in assoc(s, :tournament_reservations),
-      left_join: t in assoc(tr, :tournament),
       where: is_nil(s.deleted_at),
       where: s.station_number == ^station_number,
       preload: [
         reservations:
           ^from(
             r in Reservation,
+            where: r.start_date < ^now,
+            where: r.end_date > ^now,
+            where: is_nil(r.deleted_at),
             order_by: [desc: r.inserted_at]
           ),
-        tournament_reservations: {tr, tournament: t}
+        tournament_reservations:
+          ^from(tr in TournamentReservation,
+            join: t in assoc(tr, :tournament),
+            where: t.start_date < ^now,
+            where: t.end_date > ^now,
+            where: is_nil(t.deleted_at),
+            preload: [tournament: t]
+          )
       ]
     )
     |> Repo.one()

--- a/lib/lanpartyseating/repositories/reservation_repo.ex
+++ b/lib/lanpartyseating/repositories/reservation_repo.ex
@@ -10,7 +10,7 @@ defmodule Lanpartyseating.Reservation do
     field :badge, :string
     field :incident, :string
     field :deleted_at, :utc_datetime
-    field :station_id, :id
+    belongs_to :station, Lanpartyseating.Station
     field :start_date, :utc_datetime
     field :end_date, :utc_datetime
     timestamps()

--- a/lib/lanpartyseating/tasks/expiration_kickstarter.ex
+++ b/lib/lanpartyseating/tasks/expiration_kickstarter.ex
@@ -1,0 +1,32 @@
+defmodule Lanpartyseating.ExpirationKickstarter do
+  use Task
+  import Ecto.Query
+  alias Lanpartyseating.ExpireReservation, as: ExpireReservation
+  alias Lanpartyseating.Reservation, as: Reservation
+  alias Lanpartyseating.Repo, as: Repo
+
+  def start_link(arg) do
+    Task.start_link(__MODULE__, :run, [arg])
+  end
+
+  def run(_arg) do
+    now = DateTime.truncate(DateTime.utc_now(), :second)
+
+    from(r in Reservation,
+      where: r.end_date > ^now,
+      where: r.start_date < ^now,
+      where: is_nil(r.deleted_at)
+    )
+    |> Repo.all()
+    |> Enum.each(fn res ->
+      expiry_time = DateTime.diff(res.end_date, now, :millisecond)
+
+      Task.Supervisor.start_child(
+        Lanpartyseating.ExpirationTaskSupervisor,
+        ExpireReservation,
+        :run,
+        [{expiry_time, res.id}]
+      )
+    end)
+  end
+end

--- a/lib/lanpartyseating/tasks/expire_reservation.ex
+++ b/lib/lanpartyseating/tasks/expire_reservation.ex
@@ -1,0 +1,44 @@
+defmodule Lanpartyseating.ExpireReservation do
+  use Task
+  import Ecto.Query
+  import Ecto.Changeset
+  require Logger
+  alias Lanpartyseating.Reservation, as: Reservation
+  alias Lanpartyseating.Repo, as: Repo
+  alias Lanpartyseating.PubSub, as: PubSub
+
+  def start_link(arg) do
+    Task.start_link(__MODULE__, :run, [arg])
+  end
+
+  def run({delay, reservation_id}) do
+    Logger.debug("Expiring reservation #{reservation_id} in #{delay} milliseconds")
+    Process.sleep(delay)
+    Logger.debug("Expiring reservation #{reservation_id}")
+
+    reservation =
+      from(r in Reservation,
+        where: r.id == ^reservation_id,
+        join: s in assoc(r, :station),
+        preload: [station: s]
+      )
+      |> Repo.one()
+
+    now = DateTime.truncate(DateTime.utc_now(), :second)
+
+    deletion =
+      change(reservation, deleted_at: now)
+      |> Repo.update()
+
+    case deletion do
+      {:ok, _} ->
+        Logger.debug("Reservation #{reservation_id} expired")
+
+        Phoenix.PubSub.broadcast(
+          PubSub,
+          "station_status",
+          {:available, reservation.station.station_number}
+        )
+    end
+  end
+end

--- a/lib/lanpartyseating_web/components/modal.ex
+++ b/lib/lanpartyseating_web/components/modal.ex
@@ -4,6 +4,7 @@ defmodule ModalComponent do
   # Optionally also bring the HTML helpers
   # use Phoenix.HTML
 
+  attr :error, :string, required: false
   attr :station, :any, required: true
   attr :status, :any, required: true
   attr :reservation, :any, required: true
@@ -30,9 +31,13 @@ defmodule ModalComponent do
 
               <form phx-submit="reserve_seat">
                 <input type="hidden" name="seat_number" value={"#{@station.station_number}"}>
-                <input type="number" placeholder="Reservation duration" min="15" max="60" class="w-16 max-w-xs input input-bordered input-xs" name="duration" value="45"/> minutes
+                <input type="number" placeholder="Reservation duration" min="1" max="60" class="w-16 max-w-xs input input-bordered input-xs" name="duration" value="45"/> minutes
+                <%= if !is_nil(@error) do %>
+                  <p class="text-error"><%= @error %></p>
+                <% end %>
+                <%!-- <p>@error</p> --%>
                 <br/><br/>
-                <input type="text" placeholder="Badge number" class="w-full max-w-xs input input-bordered" name="badge_number"/>
+                <input type="text" placeholder="Badge number" class="w-full max-w-xs input input-bordered" name="badge_number" autofocus/>
 
                 <div class="modal-action">
                   <label for={"seat-modal-#{@station.station_number}"} class="btn">Close</label>


### PR DESCRIPTION
* Fixes SQL queries to determine station status
  * Only tournaments reservations for tournaments currently in progress are returned
  * Only reservations for reservations currently in progress are returned

* Started work on propagating reservation errors from to the management page
  * Errors are propagated but not yet displayed in the modal component, needs UI work
  
 * Implemented background tasks to automatically expire reservations
   * Expired reservations are set deleted in the db after their end time lapses
   * Pubsub messages are sent to mark stations with expired reservations available
   * Can add LDAP logic there
   * Expiration tasks are created for active reservations on app start up in case of restart/crash
   
 * Fixed bug for deleting reservations if a station somehow ends up with more than one active reservation