### PR TITLE
Adding TournamentReservation to tournament creation.

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -8,12 +8,12 @@ config :tzdata,
 config :lanpartyseating, LanpartyseatingWeb.Endpoint,
   url: [host: System.get_env("PHX_HOST") || "localhost", port: 4000]
 
-# config :opentelemetry,
-#   span_processor: :batch,
-#   traces_exporter: :otlp
+config :opentelemetry,
+  span_processor: :batch,
+  traces_exporter: :otlp
 
-# config :opentelemetry_exporter,
-#   otlp_protocol: :grpc,
-#   otlp_compression: :gzip,
-#   otlp_endpoint: "https://api.honeycomb.io:443",
-#   otlp_headers: [{"x-honeycomb-dataset", "lanparty-seating"}]
+config :opentelemetry_exporter,
+  otlp_protocol: :grpc,
+  otlp_compression: :gzip,
+  otlp_endpoint: "https://api.honeycomb.io:443",
+  otlp_headers: [{"x-honeycomb-dataset", "lanparty-seating"}]

--- a/lib/lanpartyseating/application.ex
+++ b/lib/lanpartyseating/application.ex
@@ -21,7 +21,7 @@ defmodule Lanpartyseating.Application do
       LanpartyseatingWeb.Endpoint,
       # Start a worker by calling: Lanpartyseating.Worker.start_link(arg)
       # {Lanpartyseating.Worker, arg}
-      {Task.Supervisor, name: Lanpartyseating.ExpirationTaskSupervisor},
+      {DynamicSupervisor, strategy: :one_for_one, name: Lanpartyseating.ExpirationTaskSupervisor},
       Lanpartyseating.ExpirationKickstarter,
     ]
 

--- a/lib/lanpartyseating/logic/badge_scan_logs_logic.ex
+++ b/lib/lanpartyseating/logic/badge_scan_logs_logic.ex
@@ -1,5 +1,4 @@
 defmodule Lanpartyseating.BadgeScanLogsLogic do
-  import Ecto.Query
   alias Lanpartyseating.BadgeScanLogs, as: BadgeScanLogs
   alias Lanpartyseating.Repo, as: Repo
 

--- a/lib/lanpartyseating/logic/station_logic.ex
+++ b/lib/lanpartyseating/logic/station_logic.ex
@@ -3,7 +3,6 @@ defmodule Lanpartyseating.StationLogic do
   use Timex
   alias Lanpartyseating.Reservation, as: Reservation
   alias Lanpartyseating.Station, as: Station
-  alias Lanpartyseating.Tournament, as: Tournament
   alias Lanpartyseating.TournamentReservation, as: TournamentReservation
   alias Lanpartyseating.Repo, as: Repo
 
@@ -137,5 +136,15 @@ defmodule Lanpartyseating.StationLogic do
       %Station{} ->
         %{status: :available, reservation: nil}
     end
+  end
+
+  def get_stations_by_range(start_number, end_number) do
+    from(s in Station,
+      order_by: [asc: s.station_number],
+      where: is_nil(s.deleted_at),
+      where: s.station_number >= ^start_number,
+      where: s.station_number <= ^end_number
+    )
+    |> Repo.all()
   end
 end

--- a/lib/lanpartyseating/logic/tournament_reservations_logic.ex
+++ b/lib/lanpartyseating/logic/tournament_reservations_logic.ex
@@ -1,0 +1,19 @@
+defmodule Lanpartyseating.TournamentReservationLogic do
+  alias Lanpartyseating.StationLogic
+  alias Lanpartyseating.TournamentReservation
+  alias Lanpartyseating.Repo, as: Repo
+
+  def create_tournament_reservations_by_range(start_station, end_station, tournament_id) do
+    StationLogic.get_stations_by_range(
+      String.to_integer(start_station, 10),
+      String.to_integer(end_station, 10)
+    )
+    |> Enum.map(fn station ->
+      %TournamentReservation{
+        tournament_id: tournament_id,
+        station_id: station.id
+      }
+    end)
+    |> Repo.insert_all()
+  end
+end

--- a/lib/lanpartyseating/logic/tournament_reservations_logic.ex
+++ b/lib/lanpartyseating/logic/tournament_reservations_logic.ex
@@ -1,9 +1,27 @@
 defmodule Lanpartyseating.TournamentReservationLogic do
+  alias Lanpartyseating.SettingsLogic
   alias Lanpartyseating.StationLogic
   alias Lanpartyseating.TournamentReservation
   alias Lanpartyseating.Repo, as: Repo
 
   def create_tournament_reservations_by_range(start_station, end_station, tournament_id) do
+    # Input validation
+    settings = SettingsLogic.get_settings()
+
+    cond do
+      start_station < 1 or start_station > settings.columns * settings.rows ->
+        {:error, "Start station is out of bounds"}
+
+      end_station < 1 or end_station > settings.columns * settings.rows ->
+        {:error, "End station is out of bounds"}
+
+      start_station > end_station ->
+        {:error, "Start station is after end station"}
+
+      true ->
+        :ok
+    end
+
     StationLogic.get_stations_by_range(
       String.to_integer(start_station, 10),
       String.to_integer(end_station, 10)

--- a/lib/lanpartyseating/logic/tournaments_logic.ex
+++ b/lib/lanpartyseating/logic/tournaments_logic.ex
@@ -33,8 +33,7 @@ defmodule Lanpartyseating.TournamentsLogic do
     end
   end
 
-  def delete_tournament(string_id) do
-    {id, _} = Integer.parse(string_id)
+  def delete_tournament(id) do
 
     Tournament
     |> where(id: ^id)
@@ -47,7 +46,11 @@ defmodule Lanpartyseating.TournamentsLogic do
         )
 
       case Repo.update(tournament) do
-        {:ok, struct} -> {:ok, struct}
+        {:ok, struct} ->
+          GenServer.cast(:"expire_tournament_#{id}", :terminate)
+          GenServer.cast(:"start_tournament_#{id}", :terminate)
+          # TODO: Pubsub broadcast to mark stations :available
+          {:ok, struct}
       end
     end)
   end

--- a/lib/lanpartyseating/logic/tournaments_logic.ex
+++ b/lib/lanpartyseating/logic/tournaments_logic.ex
@@ -1,6 +1,5 @@
 defmodule Lanpartyseating.TournamentsLogic do
   import Ecto.Query
-  alias Lanpartyseating.TournamentReservation
   alias Lanpartyseating.Tournament, as: Tournament
   alias Lanpartyseating.Repo, as: Repo
 
@@ -26,48 +25,30 @@ defmodule Lanpartyseating.TournamentsLogic do
     |> Repo.all()
   end
 
-  def create_tournament(name, start_time, duration, start_station, end_station) do
+  def create_tournament(name, start_time, duration) do
     end_time = DateTime.add(start_time, duration, :hour, Tzdata.TimeZoneDatabase)
 
-    {:ok, tournament} =
-      Repo.insert(%Tournament{start_date: start_time, end_date: end_time, name: name})
-
-    {:ok, stations} = create_reservation_list([], start_station, end_station, tournament.id)
-
-    Repo.insert_all(TournamentReservation, stations)
-
-    {:ok, "Test"}
-  end
-
-  def create_reservation_list(stations, current_station, end_station, tournament_id)
-      when current_station <= end_station do
-    stations = stations ++ [%{station_id: current_station, tournament_id: tournament_id}]
-
-    if current_station < end_station do
-      ^stations =
-        create_reservation_list(stations, current_station + 1, end_station, tournament_id)
+    case Repo.insert(%Tournament{start_date: start_time, end_date: end_time, name: name}) do
+      {:ok, tournament} -> {:ok, tournament}
     end
-
-    {:ok, stations}
   end
 
   def delete_tournament(string_id) do
     {id, _} = Integer.parse(string_id)
 
-    tournament =
-      Tournament
-      |> where(id: ^id)
-      |> where([v], is_nil(v.deleted_at))
-      |> Repo.all()
-      |> Enum.map(fn res ->
-        tournament =
-          Ecto.Changeset.change(res,
-            deleted_at: DateTime.truncate(DateTime.utc_now(), :second)
-          )
+    Tournament
+    |> where(id: ^id)
+    |> where([v], is_nil(v.deleted_at))
+    |> Repo.all()
+    |> Enum.map(fn res ->
+      tournament =
+        Ecto.Changeset.change(res,
+          deleted_at: DateTime.truncate(DateTime.utc_now(), :second)
+        )
 
-        case Repo.update(tournament) do
-          {:ok, struct} -> {:ok, struct}
-        end
-      end)
+      case Repo.update(tournament) do
+        {:ok, struct} -> {:ok, struct}
+      end
+    end)
   end
 end

--- a/lib/lanpartyseating/tasks/expire_tournament.ex
+++ b/lib/lanpartyseating/tasks/expire_tournament.ex
@@ -1,0 +1,50 @@
+defmodule Lanpartyseating.Tasks.ExpireTournament do
+  use GenServer, restart: :transient
+  import Ecto.Query
+  require Logger
+  alias Lanpartyseating.Tournament, as: Tournament
+  alias Lanpartyseating.Repo, as: Repo
+  alias Lanpartyseating.PubSub, as: PubSub
+
+  def start_link(arg) do
+    {_, tournament_id} = arg
+    GenServer.start_link(__MODULE__, arg, name: :"expire_tournament_#{tournament_id}")
+  end
+
+  @impl true
+  def init({end_date, tournament_id}) do
+    delay = DateTime.diff(end_date, DateTime.truncate(DateTime.utc_now(), :second), :millisecond) |> max(0)
+    Logger.debug("Expiring tournament #{tournament_id} in #{delay} milliseconds")
+    Process.send_after(self(), :expire_tournament, delay)
+    {:ok, tournament_id}
+  end
+
+  @impl true
+  def handle_cast(:terminate, state) do
+    Logger.debug("Terminating reservation expiration task for #{state}")
+    {:stop, :normal, state}
+  end
+
+  @impl true
+  def handle_info(:expire_tournament, tournament_id) do
+    Logger.debug("Expiring tournament #{tournament_id}")
+
+    tournament =
+      from(t in Tournament,
+        where: t.id == ^tournament_id,
+        join: tr in assoc(t, :tournament_reservations),
+        join: s in assoc(tr, :station),
+        preload: [tournament_reservations: {tr, station: s}]
+      ) |> Repo.one()
+
+    Enum.map(tournament.tournament_reservations, fn reservation ->
+      Phoenix.PubSub.broadcast(
+        PubSub,
+        "station_status",
+        {:available, reservation.station.station_number}
+      )
+    end)
+
+    {:noreply, tournament_id}
+  end
+end

--- a/lib/lanpartyseating/tasks/start_tournament.ex
+++ b/lib/lanpartyseating/tasks/start_tournament.ex
@@ -1,0 +1,49 @@
+defmodule Lanpartyseating.Tasks.StartTournament do
+  use GenServer, restart: :transient
+  import Ecto.Query
+  require Logger
+  alias Lanpartyseating.Tournament, as: Tournament
+  alias Lanpartyseating.Repo, as: Repo
+  alias Lanpartyseating.PubSub, as: PubSub
+
+  def start_link(arg) do
+    {_, tournament_id} = arg
+    GenServer.start_link(__MODULE__, arg, name: :"start_tournament_#{tournament_id}")
+  end
+
+  @impl true
+  def init({start_date, tournament_id}) do
+    delay = DateTime.diff(start_date, DateTime.truncate(DateTime.utc_now(), :second), :millisecond) |> max(0)
+    Logger.debug("Starting tournament #{tournament_id} in #{delay} milliseconds")
+    Process.send_after(self(), :expire_tournament, delay)
+    {:ok, tournament_id}
+  end
+
+  @impl true
+  def handle_cast(:terminate, state) do
+    Logger.debug("Terminating reservation expiration task for #{state}")
+    {:stop, :normal, state}
+  end
+
+  @impl true
+  def handle_info(:expire_tournament, tournament_id) do
+    Logger.debug("Starting tournament #{tournament_id}")
+
+    tournament =
+      from(t in Tournament,
+        where: t.id == ^tournament_id,
+        join: tr in assoc(t, :tournament_reservations),
+        join: s in assoc(tr, :station),
+        preload: [tournament_reservations: {tr, station: s}]
+      ) |> Repo.one()
+
+    Enum.map(tournament.tournament_reservations, fn reservation ->
+      Phoenix.PubSub.broadcast(
+        PubSub,
+        "station_status",
+        {:reserved, reservation.station.station_number, reservation}
+      )
+    end)
+    {:noreply, tournament_id}
+  end
+end

--- a/lib/lanpartyseating_web/components/tournament_modal.ex
+++ b/lib/lanpartyseating_web/components/tournament_modal.ex
@@ -23,8 +23,6 @@ defmodule TournamentModalComponent do
           <input
             type="datetime-local"
             class="w-full max-w-xs input input-bordered"
-            min="2023-08-10T00:00"
-            max="2023-08-14T00:00"
             name="start_time"
           />
           <br />

--- a/lib/lanpartyseating_web/components/tournament_modal.ex
+++ b/lib/lanpartyseating_web/components/tournament_modal.ex
@@ -31,6 +31,14 @@ defmodule TournamentModalComponent do
           <label for="duration" class="">Duration:</label>
           <input id="duration" name="duration" class=" input input-bordered" type="number" />
 
+          <br />
+          <label for="start_seat" class="">Starting Seat:</label>
+          <input id="start_seat" name="start_seat" class=" input input-bordered" type="number" />
+
+          <br />
+          <label for="end_seat" class="">Last Seating:</label>
+          <input id="end_seat" name="end_seat" class=" input input-bordered" type="number" />
+
           <div class="modal-action">
             <label for="tournament-modal" class="btn">Close</label>
             <button for="tournament-modal" class="btn" type="submit">Create</button>

--- a/lib/lanpartyseating_web/components/tournament_modal.ex
+++ b/lib/lanpartyseating_web/components/tournament_modal.ex
@@ -32,12 +32,12 @@ defmodule TournamentModalComponent do
           <input id="duration" name="duration" class=" input input-bordered" type="number" />
 
           <br />
-          <label for="start_seat" class="">Starting Seat:</label>
-          <input id="start_seat" name="start_seat" class=" input input-bordered" type="number" />
+          <label for="start_station" class="">Starting Seat:</label>
+          <input id="start_station" name="start_station" class=" input input-bordered" type="number" />
 
           <br />
-          <label for="end_seat" class="">Last Seating:</label>
-          <input id="end_seat" name="end_seat" class=" input input-bordered" type="number" />
+          <label for="end_station" class="">Last Seating:</label>
+          <input id="end_station" name="end_station" class=" input input-bordered" type="number" />
 
           <div class="modal-action">
             <label for="tournament-modal" class="btn">Close</label>

--- a/lib/lanpartyseating_web/live/tournaments_live.ex
+++ b/lib/lanpartyseating_web/live/tournaments_live.ex
@@ -1,4 +1,5 @@
 defmodule LanpartyseatingWeb.TournamentsLive do
+  alias Lanpartyseating.TournamentReservationLogic
   use LanpartyseatingWeb, :live_view
   alias Lanpartyseating.TournamentsLogic, as: TournamentsLogic
 
@@ -36,8 +37,8 @@ defmodule LanpartyseatingWeb.TournamentsLive do
           "name" => name,
           "start_time" => start_time,
           "duration" => duration,
-          "start_seat" => start_seat,
-          "end_seat" => end_seat
+          "start_station" => start_station,
+          "end_station" => end_station
         },
         socket
       ) do
@@ -49,12 +50,17 @@ defmodule LanpartyseatingWeb.TournamentsLive do
 
     {:ok, start_time} = DateTime.shift_zone(start_time, "Etc/UTC", Tzdata.TimeZoneDatabase)
 
-    TournamentsLogic.create_tournament(
-      name,
-      start_time,
-      String.to_integer(duration, 10),
-      String.to_integer(start_seat, 10),
-      String.to_integer(end_seat, 10)
+    {:ok, tournament} =
+      TournamentsLogic.create_tournament(
+        name,
+        start_time,
+        String.to_integer(duration, 10)
+      )
+
+    TournamentReservationLogic.create_tournament_reservations_by_range(
+      String.to_integer(start_station, 10),
+      String.to_integer(end_station, 10),
+      tournament.id
     )
 
     # TODO:

--- a/lib/lanpartyseating_web/live/tournaments_live.ex
+++ b/lib/lanpartyseating_web/live/tournaments_live.ex
@@ -15,17 +15,30 @@ defmodule LanpartyseatingWeb.TournamentsLive do
 
   def handle_event(
         "delete_tournament",
-        %{"id" => id},
+        %{"tournament_id" => id},
         socket
       ) do
     TournamentsLogic.delete_tournament(id)
-    # TODO: pubsub
+
+    # TODO:
+    # Phoenix.PubSub.broadcast(
+    #   PubSub,
+    #   "station_status",
+    #   {:available, String.to_integer(station_number)}
+    # )
+
     {:noreply, socket}
   end
 
   def handle_event(
         "create_tournament",
-        %{"name" => name, "start_time" => start_time, "duration" => duration},
+        %{
+          "name" => name,
+          "start_time" => start_time,
+          "duration" => duration,
+          "start_seat" => start_seat,
+          "end_seat" => end_seat
+        },
         socket
       ) do
     # 2023-08-11T13:03
@@ -36,14 +49,20 @@ defmodule LanpartyseatingWeb.TournamentsLive do
 
     {:ok, start_time} = DateTime.shift_zone(start_time, "Etc/UTC", Tzdata.TimeZoneDatabase)
 
-    case TournamentsLogic.create_tournament(
-           name,
-           start_time,
-           String.to_integer(duration, 10)
-         ) do
-      # TODO: new pubsub tournament
-      {:ok, _} -> "ok"
-    end
+    TournamentsLogic.create_tournament(
+      name,
+      start_time,
+      String.to_integer(duration, 10),
+      String.to_integer(start_seat, 10),
+      String.to_integer(end_seat, 10)
+    )
+
+    # TODO:
+    # Phoenix.PubSub.broadcast(
+    #   PubSub,
+    #   "tournament_created",
+    #   {:available, String.to_integer(station_number)}
+    # )
 
     {:noreply, socket}
   end
@@ -94,7 +113,7 @@ defmodule LanpartyseatingWeb.TournamentsLive do
             </div>
             <div class="flex flex-col flex-1 mx-1 h-14 grow" }>
               <form phx-submit="delete_tournament">
-                <input type="hidden" name="id" value={tournament.id} />
+                <input type="hidden" name="tournament_id" value={tournament.id} />
                 <button class="btn" type="submit">Delete</button>
               </form>
           </div>

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -12,72 +12,73 @@
 
 # A few regular reservations
 
-Lanpartyseating.Repo.insert!(%Lanpartyseating.Tournament{
-  start_date: ~U[2023-08-11 17:30:00Z],
-  end_date: ~U[2023-08-11 20:30:00Z],
-  name: "League of Legends"
-})
+# Lanpartyseating.Repo.insert!(%Lanpartyseating.Tournament{
+#   start_date: ~U[2023-08-11 17:30:00Z],
+#   end_date: ~U[2023-08-11 20:30:00Z],
+#   name: "League of Legends"
+# })
 
-Lanpartyseating.Repo.insert!(%Lanpartyseating.Tournament{
-  start_date: ~U[2023-08-12 17:30:00Z],
-  end_date: ~U[2023-08-12 20:30:00Z],
-  name: "League of Legends"
-})
+# Lanpartyseating.Repo.insert!(%Lanpartyseating.Tournament{
+#   start_date: ~U[2023-08-12 17:30:00Z],
+#   end_date: ~U[2023-08-12 20:30:00Z],
+#   name: "League of Legends"
+# })
 
-Lanpartyseating.Repo.insert!(%Lanpartyseating.Tournament{
-  start_date: ~U[2023-08-13 17:30:00Z],
-  end_date: ~U[2023-08-13 20:30:00Z],
-  name: "League of Legends"
-})
+# Lanpartyseating.Repo.insert!(%Lanpartyseating.Tournament{
+#   start_date: ~U[2023-08-13 17:30:00Z],
+#   end_date: ~U[2023-08-13 20:30:00Z],
+#   name: "League of Legends"
+# })
 
-Lanpartyseating.Repo.insert!(%Lanpartyseating.Tournament{
-  start_date: ~U[2023-08-11 22:30:00Z],
-  end_date: ~U[2023-08-12 01:30:00Z],
-  name: "Rainbow Six Siege"
-})
+# Lanpartyseating.Repo.insert!(%Lanpartyseating.Tournament{
+#   start_date: ~U[2023-08-11 22:30:00Z],
+#   end_date: ~U[2023-08-12 01:30:00Z],
+#   name: "Rainbow Six Siege"
+# })
 
-Lanpartyseating.Repo.insert!(%Lanpartyseating.Tournament{
-  start_date: ~U[2023-08-12 22:30:00Z],
-  end_date: ~U[2023-08-13 01:30:00Z],
-  name: "Rainbow Six Siege"
-})
+# Lanpartyseating.Repo.insert!(%Lanpartyseating.Tournament{
+#   start_date: ~U[2023-08-12 22:30:00Z],
+#   end_date: ~U[2023-08-13 01:30:00Z],
+#   name: "Rainbow Six Siege"
+# })
 
-for val <- 1..225, do:
-Lanpartyseating.Repo.insert!(%Lanpartyseating.Station{
-  station_number: val,
-  display_order: val,
-  is_closed: false
-})
+for val <- 1..225,
+    do:
+      Lanpartyseating.Repo.insert!(%Lanpartyseating.Station{
+        station_number: val,
+        display_order: val,
+        is_closed: false
+      })
 
-for val <- 1..225, do:
-Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
-  station_id: val,
-  tournament_id: 1,
-})
+# for val <- 1..225, do:
+# Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
+#   station_id: val,
+#   tournament_id: 1,
+# })
 
-for val <- 1..225, do:
-Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
-  station_id: val,
-  tournament_id: 2,
-})
+# for val <- 1..225, do:
+# Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
+#   station_id: val,
+#   tournament_id: 2,
+# })
 
-for val <- 1..225, do:
-Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
-  station_id: val,
-  tournament_id: 3,
-})
+# for val <- 1..225, do:
+# Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
+#   station_id: val,
+#   tournament_id: 3,
+# })
 
-for val <- 1..225, do:
-Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
-  station_id: val,
-  tournament_id: 4,
-})
+# for val <- 1..225, do:
+# Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
+#   station_id: val,
+#   tournament_id: 4,
+# })
 
-for val <- 1..225, do:
-Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
-  station_id: val,
-  tournament_id: 5,
-})
+# for val <- 1..225, do:
+# Lanpartyseating.Repo.insert!(%Lanpartyseating.TournamentReservation{
+#   station_id: val,
+#   tournament_id: 5,
+# })
 
 # Create only data required in this table: The last assigned seat ID.
 Lanpartyseating.Repo.insert!(%Lanpartyseating.LastAssignedSeat{
@@ -86,12 +87,13 @@ Lanpartyseating.Repo.insert!(%Lanpartyseating.LastAssignedSeat{
 })
 
 # Create IDs in the Station Status table for all the stations
-for val <- 1..225, do:
-Lanpartyseating.Repo.insert!(%Lanpartyseating.StationStatus{
-  station_id: val,
-  is_assigned: false,
-  is_out_of_order: false
-})
+for val <- 1..225,
+    do:
+      Lanpartyseating.Repo.insert!(%Lanpartyseating.StationStatus{
+        station_id: val,
+        is_assigned: false,
+        is_out_of_order: false
+      })
 
 Lanpartyseating.Repo.insert!(%Lanpartyseating.Setting{
   rows: 7,


### PR DESCRIPTION
* Added seat selection for tournaments
* TournamentReservations are created for every seat in Tournament
* Ported Tasks to GenServer to allow termination
* Refactored live pages to remove logic
* Re-enabled OTEL
* Added tournament expiration and creation tasks
* Made tournaments page more dynamic