### PR TITLE
GH-100 Add maintenance page

### DIFF
--- a/lib/lanpartyseating/logic/manholelogic.ex
+++ b/lib/lanpartyseating/logic/manholelogic.ex
@@ -1,0 +1,215 @@
+defmodule Lanpartyseating.ManholeLogic do
+  @moduledoc """
+  Logic module for manhole broadcasting functionality.
+  Handles tournament start broadcasts to desktop clients.
+  """
+
+  require Logger
+  alias LanpartyseatingWeb.Endpoint
+
+  @doc """
+  Broadcasts tournament start command to a single station.
+
+  ## Parameters
+  - station_number: The station number as a string or integer
+
+  ## Returns
+  - {:ok, station_num} on success
+  - {:error, message} on validation failure or broadcast error
+  """
+  @spec broadcast_single_station(String.t() | integer()) :: {:ok, integer()} | {:error, String.t()}
+  def broadcast_single_station(station_number) do
+    case validate_single_station(station_number) do
+      {:ok, station_num} ->
+        try do
+          Endpoint.broadcast(
+            "desktop:all",
+            "tournament_start",
+            %{
+              station_number: station_num,
+            }
+          )
+
+          Logger.info("Broadcasted tournament start for station #{station_num}")
+          {:ok, station_num}
+        rescue
+          error ->
+            Logger.error("Failed to broadcast to station #{station_num}: #{inspect(error)}")
+            {:error, "Failed to broadcast tournament start command"}
+        end
+
+      {:error, message} ->
+        {:error, message}
+    end
+  end
+
+  @doc """
+  Broadcasts cancel reservation command to a single station.
+
+  ## Parameters
+  - station_number: The station number as a string or integer
+
+  ## Returns
+  - {:ok, station_num} on success
+  - {:error, message} on validation failure or broadcast error
+  """
+  @spec cancel_single_station(String.t() | integer()) :: {:ok, integer()} | {:error, String.t()}
+  def cancel_single_station(station_number) do
+    case validate_single_station(station_number) do
+      {:ok, station_num} ->
+        try do
+          Endpoint.broadcast(
+            "desktop:all",
+            "cancel_reservation",
+            %{
+              station_number: station_num,
+            }
+          )
+
+          Logger.info("Broadcasted cancel reservation for station #{station_num}")
+          {:ok, station_num}
+        rescue
+          error ->
+            Logger.error("Failed to broadcast cancel reservation to station #{station_num}: #{inspect(error)}")
+            {:error, "Failed to broadcast cancel reservation command"}
+        end
+
+      {:error, message} ->
+        {:error, message}
+    end
+  end
+
+  @doc """
+  Broadcasts cancel reservation command to a range of stations.
+
+  ## Parameters
+  - range_start: The start station number as a string or integer
+  - range_end: The end station number as a string or integer
+
+  ## Returns
+  - {:ok, start_num, end_num} on success
+  - {:error, message} on validation failure or broadcast error
+  """
+  @spec cancel_station_range(String.t() | integer(), String.t() | integer()) ::
+    {:ok, integer(), integer()} | {:error, String.t()}
+  def cancel_station_range(range_start, range_end) do
+    case validate_range(range_start, range_end) do
+      {:ok, start_num, end_num} ->
+        try do
+          Enum.each(start_num..end_num, fn station_num ->
+            Endpoint.broadcast(
+              "desktop:all",
+              "cancel_reservation",
+              %{
+                station_number: station_num,
+              }
+            )
+          end)
+
+          Logger.info("Broadcasted cancel reservation for stations #{start_num} to #{end_num}")
+          {:ok, start_num, end_num}
+        rescue
+          error ->
+            Logger.error("Failed to broadcast cancel reservation to station range #{start_num}-#{end_num}: #{inspect(error)}")
+            {:error, "Failed to broadcast cancel reservation commands"}
+        end
+
+      {:error, message} ->
+        {:error, message}
+    end
+  end
+
+  @doc """
+  Broadcasts tournament start command to a range of stations.
+
+  ## Parameters
+  - range_start: The start station number as a string or integer
+  - range_end: The end station number as a string or integer
+
+  ## Returns
+  - {:ok, start_num, end_num} on success
+  - {:error, message} on validation failure or broadcast error
+  """
+  @spec broadcast_station_range(String.t() | integer(), String.t() | integer()) ::
+    {:ok, integer(), integer()} | {:error, String.t()}
+  def broadcast_station_range(range_start, range_end) do
+    case validate_range(range_start, range_end) do
+      {:ok, start_num, end_num} ->
+        try do
+          Enum.each(start_num..end_num, fn station_num ->
+            Endpoint.broadcast(
+              "desktop:all",
+              "tournament_start",
+              %{
+                station_number: station_num,
+              }
+            )
+          end)
+
+          Logger.info("Broadcasted tournament start for stations #{start_num} to #{end_num}")
+          {:ok, start_num, end_num}
+        rescue
+          error ->
+            Logger.error("Failed to broadcast to station range #{start_num}-#{end_num}: #{inspect(error)}")
+            {:error, "Failed to broadcast tournament start commands"}
+        end
+
+      {:error, message} ->
+        {:error, message}
+    end
+  end
+
+  # Private validation functions
+
+  @spec validate_single_station(String.t() | integer()) :: {:ok, integer()} | {:error, String.t()}
+  defp validate_single_station(station_number) when is_integer(station_number) do
+    if station_number > 0 do
+      {:ok, station_number}
+    else
+      {:error, "Station number must be a positive integer"}
+    end
+  end
+
+  defp validate_single_station(station_number) when is_binary(station_number) do
+    case Integer.parse(station_number) do
+      {num, ""} when num > 0 ->
+        {:ok, num}
+      {_num, _} ->
+        {:error, "Station number must be a valid positive integer"}
+      :error ->
+        {:error, "Station number must be a valid positive integer"}
+    end
+  end
+
+  defp validate_single_station(_), do: {:error, "Station number is required"}
+
+  @spec validate_range(String.t() | integer(), String.t() | integer()) ::
+    {:ok, integer(), integer()} | {:error, String.t()}
+  defp validate_range(range_start, range_end) when is_binary(range_start) and is_binary(range_end) do
+    with {:ok, start_num} <- validate_single_station(range_start),
+         {:ok, end_num} <- validate_single_station(range_end) do
+      if start_num <= end_num do
+        {:ok, start_num, end_num}
+      else
+        {:error, "Start station must be less than or equal to end station"}
+      end
+    else
+      {:error, _} -> {:error, "Both start and end stations must be valid positive integers"}
+    end
+  end
+
+  defp validate_range(range_start, range_end) when is_integer(range_start) and is_integer(range_end) do
+    with {:ok, start_num} <- validate_single_station(range_start),
+         {:ok, end_num} <- validate_single_station(range_end) do
+      if start_num <= end_num do
+        {:ok, start_num, end_num}
+      else
+        {:error, "Start station must be less than or equal to end station"}
+      end
+    else
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  defp validate_range(_, _), do: {:error, "Both start and end stations are required"}
+end

--- a/lib/lanpartyseating_web/live/manhole_live.ex
+++ b/lib/lanpartyseating_web/live/manhole_live.ex
@@ -1,0 +1,348 @@
+defmodule LanpartyseatingWeb.ManholeLive do
+  use LanpartyseatingWeb, :live_view
+  alias Lanpartyseating.ManholeLogic
+
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:page_title, "Manhole")
+      |> assign(:single_station_number, "")
+      |> assign(:range_start, "")
+      |> assign(:range_end, "")
+      |> assign(:cancel_single_station_number, "")
+      |> assign(:cancel_range_start, "")
+      |> assign(:cancel_range_end, "")
+      |> assign(:error_message, nil)
+      |> assign(:success_message, nil)
+
+    {:ok, socket}
+  end
+
+  def handle_event("single_station_broadcast", %{"station_number" => station_number}, socket) do
+    case ManholeLogic.broadcast_single_station(station_number) do
+      {:ok, station_num} ->
+        socket =
+          socket
+          |> assign(:success_message, "Successfully broadcasted tournament start for station #{station_num}")
+          |> assign(:error_message, nil)
+          |> assign(:single_station_number, "")
+
+        {:noreply, socket}
+
+      {:error, message} ->
+        socket =
+          socket
+          |> assign(:error_message, message)
+          |> assign(:success_message, nil)
+
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("range_broadcast", %{"range_start" => range_start, "range_end" => range_end}, socket) do
+    case ManholeLogic.broadcast_station_range(range_start, range_end) do
+      {:ok, start_num, end_num} ->
+        socket =
+          socket
+          |> assign(:success_message, "Successfully broadcasted tournament start for stations #{start_num} to #{end_num}")
+          |> assign(:error_message, nil)
+          |> assign(:range_start, "")
+          |> assign(:range_end, "")
+
+        {:noreply, socket}
+
+      {:error, message} ->
+        socket =
+          socket
+          |> assign(:error_message, message)
+          |> assign(:success_message, nil)
+
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("update_single_station", %{"station_number" => station_number}, socket) do
+    {:noreply, assign(socket, :single_station_number, station_number)}
+  end
+
+  def handle_event("update_range_start", %{"range_start" => range_start}, socket) do
+    {:noreply, assign(socket, :range_start, range_start)}
+  end
+
+  def handle_event("update_range_end", %{"range_end" => range_end}, socket) do
+    {:noreply, assign(socket, :range_end, range_end)}
+  end
+
+  def handle_event("cancel_single_station", %{"station_number" => station_number}, socket) do
+    case ManholeLogic.cancel_single_station(station_number) do
+      {:ok, station_num} ->
+        socket =
+          socket
+          |> assign(:success_message, "Successfully cancelled reservation for station #{station_num}")
+          |> assign(:error_message, nil)
+          |> assign(:cancel_single_station_number, "")
+
+        {:noreply, socket}
+
+      {:error, message} ->
+        socket =
+          socket
+          |> assign(:error_message, message)
+          |> assign(:success_message, nil)
+
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("cancel_range", %{"range_start" => range_start, "range_end" => range_end}, socket) do
+    case ManholeLogic.cancel_station_range(range_start, range_end) do
+      {:ok, start_num, end_num} ->
+        socket =
+          socket
+          |> assign(:success_message, "Successfully cancelled reservations for stations #{start_num} to #{end_num}")
+          |> assign(:error_message, nil)
+          |> assign(:cancel_range_start, "")
+          |> assign(:cancel_range_end, "")
+
+        {:noreply, socket}
+
+      {:error, message} ->
+        socket =
+          socket
+          |> assign(:error_message, message)
+          |> assign(:success_message, nil)
+
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("update_cancel_single_station", %{"station_number" => station_number}, socket) do
+    {:noreply, assign(socket, :cancel_single_station_number, station_number)}
+  end
+
+  def handle_event("update_cancel_range_start", %{"range_start" => range_start}, socket) do
+    {:noreply, assign(socket, :cancel_range_start, range_start)}
+  end
+
+  def handle_event("update_cancel_range_end", %{"range_end" => range_end}, socket) do
+    {:noreply, assign(socket, :cancel_range_end, range_end)}
+  end
+
+  # Clear messages when user starts typing
+  def handle_event("clear_messages", _params, socket) do
+    socket =
+      socket
+      |> assign(:error_message, nil)
+      |> assign(:success_message, nil)
+
+    {:noreply, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="container mx-auto px-4 py-4">
+      <h1 class="text-3xl font-bold mb-6">Manhole - Tournament & Station Control</h1>
+
+      <!-- Warning Notice -->
+      <div class="alert alert-warning mb-6">
+        <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 15.5c-.77.833.192 2.5 1.732 2.5z" />
+        </svg>
+        <span>This is an administrative tool. Use with caution as it directly controls tournament and reservation states on desktop clients.</span>
+      </div>
+
+      <%= if @error_message do %>
+        <div class="alert alert-error mb-4">
+          <span><%= @error_message %></span>
+        </div>
+      <% end %>
+
+      <%= if @success_message do %>
+        <div class="alert alert-success mb-4">
+          <span><%= @success_message %></span>
+        </div>
+      <% end %>
+
+      <!-- Tournament Start Controls -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4 text-error">Tournament Start Controls</h2>
+
+        <!-- Single Station Tournament Start -->
+        <div class="card bg-base-100 shadow-xl mb-6">
+          <div class="card-body">
+            <h3 class="card-title text-error">Single Station Tournament Start</h3>
+            <p class="text-base-content/70">Broadcast tournament start command to a single station</p>
+
+            <form phx-submit="single_station_broadcast" class="form-control w-full max-w-xs">
+              <label class="label">
+                <span class="label-text">Station Number</span>
+              </label>
+              <input
+                type="number"
+                min="1"
+                step="1"
+                placeholder="Enter station number"
+                class="input input-bordered w-full max-w-xs"
+                name="station_number"
+                value={@single_station_number}
+                phx-change="update_single_station"
+                phx-focus="clear_messages"
+                required
+              />
+              <div class="card-actions justify-end mt-4">
+                <button type="submit" class="btn btn-error">
+                  Start Tournament
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <!-- Range Tournament Start -->
+        <div class="card bg-base-100 shadow-xl mb-6">
+          <div class="card-body">
+            <h3 class="card-title text-error">Station Range Tournament Start</h3>
+            <p class="text-base-content/70">Broadcast tournament start command to a range of stations</p>
+
+            <form phx-submit="range_broadcast" class="form-control">
+              <div class="flex gap-4 items-end">
+                <div class="form-control w-full max-w-xs">
+                  <label class="label">
+                    <span class="label-text">Start Station</span>
+                  </label>
+                  <input
+                    type="number"
+                    min="1"
+                    step="1"
+                    placeholder="Start station"
+                    class="input input-bordered w-full max-w-xs"
+                    name="range_start"
+                    value={@range_start}
+                    phx-change="update_range_start"
+                    phx-focus="clear_messages"
+                    required
+                  />
+                </div>
+
+                <div class="form-control w-full max-w-xs">
+                  <label class="label">
+                    <span class="label-text">End Station</span>
+                  </label>
+                  <input
+                    type="number"
+                    min="1"
+                    step="1"
+                    placeholder="End station"
+                    class="input input-bordered w-full max-w-xs"
+                    name="range_end"
+                    value={@range_end}
+                    phx-change="update_range_end"
+                    phx-focus="clear_messages"
+                    required
+                  />
+                </div>
+
+                <div class="card-actions">
+                  <button type="submit" class="btn btn-error">
+                    Start Tournament Range
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      <!-- Cancel Reservation Controls -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-semibold mb-4 text-error">Cancel Reservation Controls</h2>
+
+        <!-- Single Station Cancel -->
+        <div class="card bg-base-100 shadow-xl mb-6">
+          <div class="card-body">
+            <h3 class="card-title text-error">Single Station Logout</h3>
+            <p class="text-base-content/70">Cancel reservation and log out a single station</p>
+
+            <form phx-submit="cancel_single_station" class="form-control w-full max-w-xs">
+              <label class="label">
+                <span class="label-text">Station Number</span>
+              </label>
+              <input
+                type="number"
+                min="1"
+                step="1"
+                placeholder="Enter station number"
+                class="input input-bordered w-full max-w-xs"
+                name="station_number"
+                value={@cancel_single_station_number}
+                phx-change="update_cancel_single_station"
+                phx-focus="clear_messages"
+                required
+              />
+              <div class="card-actions justify-end mt-4">
+                <button type="submit" class="btn btn-error">
+                  Cancel Reservation
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <!-- Range Cancel -->
+        <div class="card bg-base-100 shadow-xl mb-6">
+          <div class="card-body">
+            <h3 class="card-title text-error">Station Range Logout</h3>
+            <p class="text-base-content/70">Cancel reservations and log out a range of stations</p>
+
+            <form phx-submit="cancel_range" class="form-control">
+              <div class="flex gap-4 items-end">
+                <div class="form-control w-full max-w-xs">
+                  <label class="label">
+                    <span class="label-text">Start Station</span>
+                  </label>
+                  <input
+                    type="number"
+                    min="1"
+                    step="1"
+                    placeholder="Start station"
+                    class="input input-bordered w-full max-w-xs"
+                    name="range_start"
+                    value={@cancel_range_start}
+                    phx-change="update_cancel_range_start"
+                    phx-focus="clear_messages"
+                    required
+                  />
+                </div>
+
+                <div class="form-control w-full max-w-xs">
+                  <label class="label">
+                    <span class="label-text">End Station</span>
+                  </label>
+                  <input
+                    type="number"
+                    min="1"
+                    step="1"
+                    placeholder="End station"
+                    class="input input-bordered w-full max-w-xs"
+                    name="range_end"
+                    value={@cancel_range_end}
+                    phx-change="update_cancel_range_end"
+                    phx-focus="clear_messages"
+                    required
+                  />
+                </div>
+
+                <div class="card-actions">
+                  <button type="submit" class="btn btn-error">
+                    Cancel Range
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/lanpartyseating_web/router.ex
+++ b/lib/lanpartyseating_web/router.ex
@@ -38,6 +38,7 @@ defmodule LanpartyseatingWeb.Router do
       live("/tournaments", TournamentsLive, :index)
       live("/settings", SettingsLive, :index)
       live("/logs", LogsLive, :index)
+      live("/manhole", ManholeLive, :index)
     end
   end
 


### PR DESCRIPTION
Can be found at `/manhole`, hidden from navbar.
This pull request introduces a new administrative feature for controlling tournament and reservation states on desktop clients via a dedicated "Manhole" interface. The changes add backend logic for broadcasting commands to single stations or ranges of stations. Allows signing into tournament account and signing accounts out.