### PR TITLE
Use a non default port for postgres in dev

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -68,4 +68,5 @@ config :lanpartyseating, Lanpartyseating.Repo,
   password: "postgres",
   database: "lanpartyseating_dev",
   hostname: "localhost",
-  pool_size: 10
+  pool_size: 10,
+  port: 5021

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
             initialScript = ''
               CREATE USER postgres WITH SUPERUSER PASSWORD 'password';
             '';
+            port = 5021;
             listen_addresses = "::1,127.0.0.1";
           };
           env.MIX_REBAR3 = "${pkgs.rebar3}/bin/rebar3";


### PR DESCRIPTION
Because I already have a postgres database running on my pc devenv fails if I don't change the port 