### PR TITLE
Show warning if trying reserver with a badge that already has active reservation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@
 
 let
   pname = "lanpartyseating";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = ./.;
 

--- a/lib/lanpartyseating/logic/reservation_logic.ex
+++ b/lib/lanpartyseating/logic/reservation_logic.ex
@@ -70,12 +70,9 @@ defmodule Lanpartyseating.ReservationLogic do
   Returns `{:error, reason}` if the badge UID is invalid.
   """
   def check_active_reservation(uid) do
-    with {:ok, badge} <- BadgesLogic.get_badge(uid) do
-      find_active_reservations_by_badge(badge.serial_key)
-      |> case do
-        {:ok, [reservation | _]} -> {:ok, reservation}
-        {:error, :no_reservation} -> {:error, :no_reservation}
-      end
+    with {:ok, badge} <- BadgesLogic.get_badge(uid),
+         {:ok, [reservation | _]} <- find_active_reservations_by_badge(badge.serial_key) do
+      {:ok, reservation}
     end
   end
 

--- a/lib/lanpartyseating/logic/reservation_logic.ex
+++ b/lib/lanpartyseating/logic/reservation_logic.ex
@@ -63,6 +63,22 @@ defmodule Lanpartyseating.ReservationLogic do
     end
   end
 
+  @doc """
+  Checks if a badge UID already has an active (non-deleted) reservation.
+  Returns `{:ok, reservation}` with the first active reservation if one exists,
+  or `{:error, :no_reservation}` if the badge has no active reservations.
+  Returns `{:error, reason}` if the badge UID is invalid.
+  """
+  def check_active_reservation(uid) do
+    with {:ok, badge} <- BadgesLogic.get_badge(uid) do
+      find_active_reservations_by_badge(badge.serial_key)
+      |> case do
+        {:ok, [reservation | _]} -> {:ok, reservation}
+        {:error, :no_reservation} -> {:error, :no_reservation}
+      end
+    end
+  end
+
   defp check_badge_not_banned(%{is_banned: true}), do: {:error, :banned}
   defp check_badge_not_banned(_badge), do: :ok
 

--- a/lib/lanpartyseating_web/components/station_modal.ex
+++ b/lib/lanpartyseating_web/components/station_modal.ex
@@ -12,6 +12,7 @@ defmodule LanpartyseatingWeb.Components.StationModal do
   """
   use Phoenix.Component
   import LanpartyseatingWeb.Components.UI, only: [countdown: 1]
+  alias LanpartyseatingWeb.Components.Icons
 
   # ============================================================================
   # Station Button Component
@@ -158,30 +159,18 @@ defmodule LanpartyseatingWeb.Components.StationModal do
       <%= if @duplicate_warning do %>
         <%!-- Duplicate reservation warning --%>
         <div class="alert alert-warning mb-4">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="stroke-current shrink-0 h-6 w-6"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-            />
-          </svg>
+          <Icons.exclamation_triangle class="shrink-0 h-6 w-6" />
           <div>
             <p class="font-bold">
               This badge already has an active reservation at station {@duplicate_warning.station_number}!
             </p>
             <p class="text-sm">
-              Ce badge a déjà une réservation active à la station {@duplicate_warning.station_number}!
-            </p>
-            <p class="text-sm mt-1">
               Are you sure you want to create another reservation?
             </p>
-            <p class="text-xs">
+            <p class="font-bold mt-2">
+              Ce badge a déjà une réservation active à la station {@duplicate_warning.station_number}!
+            </p>
+            <p class="text-sm">
               Êtes-vous sûr de vouloir créer une autre réservation?
             </p>
           </div>

--- a/lib/lanpartyseating_web/components/station_modal.ex
+++ b/lib/lanpartyseating_web/components/station_modal.ex
@@ -135,6 +135,7 @@ defmodule LanpartyseatingWeb.Components.StationModal do
   attr :error, :string, default: nil
   attr :is_admin, :boolean, default: false
   attr :reservation_minutes, :integer, default: 45
+  attr :duplicate_warning, :any, default: nil
 
   def modal_content(assigns) do
     case assigns.status do
@@ -154,45 +155,92 @@ defmodule LanpartyseatingWeb.Components.StationModal do
     <div x-data={"{ adminOpen: #{@is_admin} }"}>
       <h3 class="text-xl font-bold mb-4">Station {@station.station_number}</h3>
 
-      <%!-- Self-service reservation section --%>
-      <div class="space-y-2 text-base-content/80">
-        <p>Once your badge is scanned, a {@reservation_minutes} min session will start at the chosen station.</p>
-        <p class="text-sm">Une fois votre badge scanné, une session de {@reservation_minutes} min commencera à la station choisie.</p>
-      </div>
-
-      <form phx-submit="reserve_station" class="mt-6">
-        <input type="hidden" name="station_number" value={@station.station_number} />
-
-        <%= if @error do %>
-          <div class="alert alert-error mb-4">
-            <span>{@error}</span>
+      <%= if @duplicate_warning do %>
+        <%!-- Duplicate reservation warning --%>
+        <div class="alert alert-warning mb-4">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="stroke-current shrink-0 h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+          <div>
+            <p class="font-bold">
+              This badge already has an active reservation at station {@duplicate_warning.station_number}!
+            </p>
+            <p class="text-sm">
+              Ce badge a déjà une réservation active à la station {@duplicate_warning.station_number}!
+            </p>
+            <p class="text-sm mt-1">
+              Are you sure you want to create another reservation?
+            </p>
+            <p class="text-xs">
+              Êtes-vous sûr de vouloir créer une autre réservation?
+            </p>
           </div>
-        <% end %>
-
-        <div class="form-control">
-          <label class="label">
-            <span class="label-text">Badge number / Numéro de badge</span>
-          </label>
-          <input
-            type="text"
-            placeholder="Enter badge number..."
-            class="input input-bordered w-full"
-            name="uid"
-            autocomplete="off"
-            id={"station-badge-input-#{@station.station_number}"}
-            phx-hook="AutoFocus"
-          />
         </div>
 
-        <div class="modal-action">
-          <button type="button" class="btn btn-ghost" phx-click="close_station_modal">
-            Cancel / Annuler
-          </button>
-          <button class="btn btn-success" type="submit">
-            Reserve / Réserver
-          </button>
+        <form phx-submit="confirm_reserve_station">
+          <input type="hidden" name="station_number" value={@duplicate_warning.target_station} />
+          <input type="hidden" name="uid" value={@duplicate_warning.badge_uid} />
+
+          <div class="modal-action">
+            <button type="button" class="btn btn-ghost" phx-click="close_station_modal">
+              Cancel / Annuler
+            </button>
+            <button class="btn btn-warning" type="submit">
+              Reserve Anyway / Réserver quand même
+            </button>
+          </div>
+        </form>
+      <% else %>
+        <%!-- Self-service reservation section --%>
+        <div class="space-y-2 text-base-content/80">
+          <p>Once your badge is scanned, a {@reservation_minutes} min session will start at the chosen station.</p>
+          <p class="text-sm">Une fois votre badge scanné, une session de {@reservation_minutes} min commencera à la station choisie.</p>
         </div>
-      </form>
+
+        <form phx-submit="reserve_station" class="mt-6">
+          <input type="hidden" name="station_number" value={@station.station_number} />
+
+          <%= if @error do %>
+            <div class="alert alert-error mb-4">
+              <span>{@error}</span>
+            </div>
+          <% end %>
+
+          <div class="form-control">
+            <label class="label">
+              <span class="label-text">Badge number / Numéro de badge</span>
+            </label>
+            <input
+              type="text"
+              placeholder="Enter badge number..."
+              class="input input-bordered w-full"
+              name="uid"
+              autocomplete="off"
+              id={"station-badge-input-#{@station.station_number}"}
+              phx-hook="AutoFocus"
+            />
+          </div>
+
+          <div class="modal-action">
+            <button type="button" class="btn btn-ghost" phx-click="close_station_modal">
+              Cancel / Annuler
+            </button>
+            <button class="btn btn-success" type="submit">
+              Reserve / Réserver
+            </button>
+          </div>
+        </form>
+      <% end %>
 
       <%!-- Admin actions collapsible section --%>
       <div class="divider"></div>

--- a/lib/lanpartyseating_web/live/stations_live.ex
+++ b/lib/lanpartyseating_web/live/stations_live.ex
@@ -50,6 +50,7 @@ defmodule LanpartyseatingWeb.StationsLive do
       |> assign(:reservation_duration_minutes, settings.reservation_duration_minutes)
       |> assign_stations(station_list)
       |> assign(:registration_error, nil)
+      |> assign(:duplicate_warning, nil)
       # Station modal state
       |> assign(:show_station_modal, false)
       |> assign(:selected_station, nil)
@@ -109,6 +110,26 @@ defmodule LanpartyseatingWeb.StationsLive do
     end
   end
 
+  defp do_create_reservation(station_number, uid, socket) do
+    duration = socket.assigns.reservation_duration_minutes
+
+    case ReservationLogic.create_reservation(String.to_integer(station_number), duration, uid) do
+      {:error, error} ->
+        {:noreply,
+         socket
+         |> assign(:registration_error, error)
+         |> assign(:duplicate_warning, nil)}
+
+      {:ok, _reservation} ->
+        {:noreply,
+         socket
+         |> assign(:registration_error, nil)
+         |> assign(:duplicate_warning, nil)
+         |> assign(:show_station_modal, false)
+         |> assign(:selected_station, nil)}
+    end
+  end
+
   # ============================================================================
   # Modal Control Events
   # ============================================================================
@@ -121,7 +142,8 @@ defmodule LanpartyseatingWeb.StationsLive do
      socket
      |> assign(:selected_station, station_data)
      |> assign(:show_station_modal, true)
-     |> assign(:registration_error, nil)}
+     |> assign(:registration_error, nil)
+     |> assign(:duplicate_warning, nil)}
   end
 
   def handle_event("close_station_modal", _params, socket) do
@@ -129,7 +151,8 @@ defmodule LanpartyseatingWeb.StationsLive do
      socket
      |> assign(:selected_station, nil)
      |> assign(:show_station_modal, false)
-     |> assign(:registration_error, nil)}
+     |> assign(:registration_error, nil)
+     |> assign(:duplicate_warning, nil)}
   end
 
   def handle_event("close_sudo_modal", _params, socket) do
@@ -145,19 +168,28 @@ defmodule LanpartyseatingWeb.StationsLive do
   # ============================================================================
 
   def handle_event("reserve_station", %{"station_number" => station_number, "uid" => uid}, socket) do
-    duration = socket.assigns.reservation_duration_minutes
-
-    case ReservationLogic.create_reservation(String.to_integer(station_number), duration, uid) do
-      {:error, error} ->
-        {:noreply, assign(socket, :registration_error, error)}
-
-      {:ok, _reservation} ->
+    # Check if this badge already has an active reservation
+    case ReservationLogic.check_active_reservation(uid) do
+      {:ok, existing_reservation} ->
+        # Badge has an active reservation — show warning, don't reserve yet
         {:noreply,
          socket
-         |> assign(:registration_error, nil)
-         |> assign(:show_station_modal, false)
-         |> assign(:selected_station, nil)}
+         |> assign(:duplicate_warning, %{
+           station_number: existing_reservation.station_id,
+           badge_uid: uid,
+           target_station: station_number,
+         })
+         |> assign(:registration_error, nil)}
+
+      {:error, _} ->
+        # No active reservation (or invalid badge — create_reservation will handle that error)
+        do_create_reservation(station_number, uid, socket)
     end
+  end
+
+  def handle_event("confirm_reserve_station", %{"station_number" => station_number, "uid" => uid}, socket) do
+    # User confirmed they want to proceed despite duplicate warning
+    do_create_reservation(station_number, uid, socket)
   end
 
   # ============================================================================
@@ -372,6 +404,7 @@ defmodule LanpartyseatingWeb.StationsLive do
               error={@registration_error}
               is_admin={@current_scope != nil && @current_scope.user != nil}
               reservation_minutes={@reservation_duration_minutes}
+              duplicate_warning={@duplicate_warning}
             />
           </.focus_wrap>
         <% end %>


### PR DESCRIPTION
Show this dialog:

<img width="1024" height="772" alt="Screenshot 2026-03-10 at 00-14-29 LAN Party Seating" src="https://github.com/user-attachments/assets/ce93f582-84a1-44b3-a259-ac66bd8cc4e5" />

If there is currently an active reservation for the badge being scanned.

Closes #96 