### PR TITLE
Replace rules with available game carousel

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,6 +4,7 @@ import Alpine from "alpinejs"
 import focus from "@alpinejs/focus"
 import BluetoothProvisioning from "./hooks/bluetooth_provisioning"
 import ButtonGridHook from "./hooks/button_grid_hook"
+import SortableListHook from "./hooks/sortable_list_hook"
 
 window.Alpine = Alpine
 Alpine.plugin(focus)
@@ -12,7 +13,8 @@ Alpine.start()
 // LiveView Hooks
 let Hooks = {
   BluetoothProvisioning,
-  ButtonGridHook
+  ButtonGridHook,
+  SortableListHook
 }
 
 // Auto-focus input when mounted (used for modal badge inputs)

--- a/assets/js/hooks/sortable_list_hook.js
+++ b/assets/js/hooks/sortable_list_hook.js
@@ -1,0 +1,116 @@
+/**
+ * SortableListHook - Handles drag and drop reordering for list items.
+ *
+ * Usage: Add `phx-hook="SortableListHook"` to the container element.
+ * Each sortable child should have a `data-id` attribute.
+ * Drag handles within children should have the `[data-drag-handle]` attribute
+ * and `draggable="true"`.
+ *
+ * On drop, pushes a "reorder" event with `{ ids: [...] }` containing
+ * the new order of data-id values.
+ */
+const SortableListHook = {
+  mounted() {
+    this.setupDragAndDrop();
+  },
+
+  updated() {
+    // Re-setup after LiveView patches the DOM
+    this.setupDragAndDrop();
+  },
+
+  setupDragAndDrop() {
+    const container = this.el;
+    let draggedItem = null;
+
+    // Clean up old listeners by replacing the container's event handling
+    // (we use event delegation so this is safe)
+    container.ondragstart = (e) => {
+      const handle = e.target.closest('[data-drag-handle]');
+      if (!handle) return;
+
+      draggedItem = handle.closest('[data-id]');
+      if (!draggedItem) return;
+
+      draggedItem.classList.add('opacity-50');
+      e.dataTransfer.effectAllowed = 'move';
+      // Required for Firefox
+      e.dataTransfer.setData('text/plain', '');
+    };
+
+    container.ondragend = () => {
+      if (draggedItem) {
+        draggedItem.classList.remove('opacity-50');
+        draggedItem = null;
+      }
+      // Remove all drop indicators
+      container.querySelectorAll('[data-id]').forEach(el => {
+        el.classList.remove('border-t-2', 'border-b-2', 'border-primary');
+      });
+    };
+
+    container.ondragover = (e) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+
+      const target = e.target.closest('[data-id]');
+      if (!target || target === draggedItem) return;
+
+      // Clear previous indicators
+      container.querySelectorAll('[data-id]').forEach(el => {
+        el.classList.remove('border-t-2', 'border-b-2', 'border-primary');
+      });
+
+      // Show drop indicator based on cursor position
+      const rect = target.getBoundingClientRect();
+      const midY = rect.top + rect.height / 2;
+      if (e.clientY < midY) {
+        target.classList.add('border-t-2', 'border-primary');
+      } else {
+        target.classList.add('border-b-2', 'border-primary');
+      }
+    };
+
+    container.ondragleave = (e) => {
+      const target = e.target.closest('[data-id]');
+      if (target) {
+        target.classList.remove('border-t-2', 'border-b-2', 'border-primary');
+      }
+    };
+
+    container.ondrop = (e) => {
+      e.preventDefault();
+      if (!draggedItem) return;
+
+      const target = e.target.closest('[data-id]');
+      if (!target || target === draggedItem) return;
+
+      // Determine if we should insert before or after target
+      const rect = target.getBoundingClientRect();
+      const midY = rect.top + rect.height / 2;
+      const insertBefore = e.clientY < midY;
+
+      // Perform the DOM move
+      if (insertBefore) {
+        target.parentNode.insertBefore(draggedItem, target);
+      } else {
+        target.parentNode.insertBefore(draggedItem, target.nextSibling);
+      }
+
+      // Collect new order and push to LiveView
+      const ids = Array.from(container.querySelectorAll('[data-id]'))
+        .map(el => parseInt(el.dataset.id));
+
+      this.pushEvent('reorder', { ids });
+
+      // Cleanup
+      draggedItem.classList.remove('opacity-50');
+      draggedItem = null;
+      container.querySelectorAll('[data-id]').forEach(el => {
+        el.classList.remove('border-t-2', 'border-b-2', 'border-primary');
+      });
+    };
+  }
+};
+
+export default SortableListHook;

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@
 
 let
   pname = "lanpartyseating";
-  version = "1.3.1";
+  version = "1.4.0";
 
   src = ./.;
 

--- a/lib/lanpartyseating/application.ex
+++ b/lib/lanpartyseating/application.ex
@@ -12,6 +12,8 @@ defmodule Lanpartyseating.Application do
       # Database must be ready before anything queries it
       Lanpartyseating.Repo,
       {Task, fn -> ensure_settings_exist() end},
+      # Carousel image cache (ETS-backed, must start after Repo)
+      Lanpartyseating.CarouselCache,
       # Telemetry and metrics
       LanpartyseatingWeb.Telemetry,
       Lanpartyseating.PromEx,

--- a/lib/lanpartyseating/carousel_cache.ex
+++ b/lib/lanpartyseating/carousel_cache.ex
@@ -1,0 +1,104 @@
+defmodule Lanpartyseating.CarouselCache do
+  @moduledoc """
+  ETS-backed GenServer that caches carousel images in memory at startup.
+
+  Images are loaded from the database once on boot and refreshed on demand
+  after CRUD operations. The ETS table is `:public` read so LiveViews can
+  read directly without bottlenecking the GenServer process.
+
+  ## Cache structure
+
+  The ETS table stores two kinds of entries:
+  - `{:image, id}` => full image map (for serving image data)
+  - `:enabled_list` => ordered list of enabled image metadata (no blob data)
+  - `:all_list` => ordered list of all image metadata (for admin, no blob data)
+  """
+  use GenServer
+
+  alias Lanpartyseating.{Repo, CarouselImage}
+  import Ecto.Query
+
+  @table :carousel_images_cache
+
+  # --- Client API ---
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc "Returns enabled carousel images ordered by display_order (metadata only, no blobs)."
+  def list_images do
+    case :ets.lookup(@table, :enabled_list) do
+      [{:enabled_list, images}] -> images
+      [] -> []
+    end
+  end
+
+  @doc "Returns all carousel images ordered by display_order (metadata only, for admin)."
+  def list_all_images do
+    case :ets.lookup(@table, :all_list) do
+      [{:all_list, images}] -> images
+      [] -> []
+    end
+  end
+
+  @doc "Returns {content_type, binary_data} for a given image ID, or nil if not found."
+  def get_image_data(id) do
+    case :ets.lookup(@table, {:image, id}) do
+      [{{:image, _}, %{content_type: ct, image_data: data}}] -> {ct, data}
+      [] -> nil
+    end
+  end
+
+  @doc "Triggers a synchronous reload from the database. Blocks until ETS is updated."
+  def refresh do
+    GenServer.call(__MODULE__, :refresh)
+  end
+
+  # --- Server callbacks ---
+
+  @impl true
+  def init(_) do
+    table = :ets.new(@table, [:set, :public, :named_table, read_concurrency: true])
+    load_from_db()
+    {:ok, %{table: table}}
+  end
+
+  @impl true
+  def handle_call(:refresh, _from, state) do
+    load_from_db()
+    {:reply, :ok, state}
+  end
+
+  defp load_from_db do
+    images =
+      from(i in CarouselImage, order_by: [asc: i.display_order, asc: i.id])
+      |> Repo.all()
+
+    # Store full image data keyed by ID (for serving)
+    # First, clear old image entries
+    :ets.match_delete(@table, {{:image, :_}, :_})
+
+    for img <- images do
+      :ets.insert(@table, {{:image, img.id}, %{content_type: img.content_type, image_data: img.image_data}})
+    end
+
+    # Store metadata lists (without blob data, for LiveView assigns)
+    metadata_fn = fn img ->
+      %{
+        id: img.id,
+        title: img.title,
+        content_type: img.content_type,
+        display_order: img.display_order,
+        enabled: img.enabled,
+        inserted_at: img.inserted_at,
+      }
+    end
+
+    all_list = Enum.map(images, metadata_fn)
+    enabled_list = all_list |> Enum.filter(& &1.enabled)
+
+    :ets.insert(@table, {:all_list, all_list})
+    :ets.insert(@table, {:enabled_list, enabled_list})
+  end
+end

--- a/lib/lanpartyseating/logic/carousel_logic.ex
+++ b/lib/lanpartyseating/logic/carousel_logic.ex
@@ -1,0 +1,124 @@
+defmodule Lanpartyseating.CarouselLogic do
+  @moduledoc """
+  Business logic for managing carousel images displayed on the public display page.
+  """
+  import Ecto.Query
+  alias Lanpartyseating.{Repo, CarouselImage, CarouselCache}
+
+  @pubsub Lanpartyseating.PubSub
+  @topic "carousel_update"
+
+  # ============================================================================
+  # Read operations (delegate to cache)
+  # ============================================================================
+
+  @doc "Returns enabled carousel images ordered by display_order (metadata only)."
+  def list_images, do: CarouselCache.list_images()
+
+  @doc "Returns all carousel images ordered by display_order (metadata only, for admin)."
+  def list_all_images, do: CarouselCache.list_all_images()
+
+  @doc "Returns {content_type, binary_data} for a given image ID, or nil."
+  def get_image_data(id), do: CarouselCache.get_image_data(id)
+
+  # ============================================================================
+  # Write operations
+  # ============================================================================
+
+  @doc """
+  Creates a new carousel image from upload data.
+  Automatically assigns the next display_order.
+  Returns {:ok, image} or {:error, changeset}.
+  """
+  def create_image(attrs) do
+    # Auto-assign display_order to end of list if not specified
+    attrs = maybe_assign_order(attrs)
+
+    case %CarouselImage{} |> CarouselImage.changeset(attrs) |> Repo.insert() do
+      {:ok, image} ->
+        refresh_and_broadcast()
+        {:ok, image}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
+  Updates carousel image metadata (title, display_order, enabled).
+  Does not replace image data — use create + delete for that.
+  Returns {:ok, image} or {:error, changeset}.
+  """
+  def update_image(id, attrs) do
+    with {:ok, image} <- get_image(id) do
+      case image |> CarouselImage.metadata_changeset(attrs) |> Repo.update() do
+        {:ok, image} ->
+          refresh_and_broadcast()
+          {:ok, image}
+
+        {:error, changeset} ->
+          {:error, changeset}
+      end
+    end
+  end
+
+  @doc """
+  Permanently deletes a carousel image.
+  Returns :ok or {:error, reason}.
+  """
+  def delete_image(id) do
+    with {:ok, image} <- get_image(id),
+         {:ok, _} <- Repo.delete(image) do
+      refresh_and_broadcast()
+      :ok
+    end
+  end
+
+  @doc """
+  Reorders images by assigning new display_order values.
+  Takes a list of image IDs in the desired order.
+  Returns :ok.
+  """
+  def reorder_images(ordered_ids) when is_list(ordered_ids) do
+    Repo.transaction(fn ->
+      ordered_ids
+      |> Enum.with_index()
+      |> Enum.each(fn {id, index} ->
+        from(i in CarouselImage, where: i.id == ^id)
+        |> Repo.update_all(set: [display_order: index])
+      end)
+    end)
+
+    refresh_and_broadcast()
+    :ok
+  end
+
+  # ============================================================================
+  # Private helpers
+  # ============================================================================
+
+  defp get_image(id) do
+    case Repo.get(CarouselImage, id) do
+      nil -> {:error, :not_found}
+      image -> {:ok, image}
+    end
+  end
+
+  defp maybe_assign_order(attrs) when is_map(attrs) do
+    if Map.has_key?(attrs, :display_order) || Map.has_key?(attrs, "display_order") do
+      attrs
+    else
+      max_order =
+        from(i in CarouselImage, select: max(i.display_order))
+        |> Repo.one()
+        |> Kernel.||(0)
+
+      Map.put(attrs, :display_order, max_order + 1)
+    end
+  end
+
+  defp refresh_and_broadcast do
+    CarouselCache.refresh()
+    Phoenix.PubSub.broadcast(@pubsub, @topic, {:carousel, :updated})
+  end
+end

--- a/lib/lanpartyseating/logic/carousel_logic.ex
+++ b/lib/lanpartyseating/logic/carousel_logic.ex
@@ -80,14 +80,21 @@ defmodule Lanpartyseating.CarouselLogic do
   Returns :ok.
   """
   def reorder_images(ordered_ids) when is_list(ordered_ids) do
-    Repo.transaction(fn ->
-      ordered_ids
-      |> Enum.with_index()
-      |> Enum.each(fn {id, index} ->
-        from(i in CarouselImage, where: i.id == ^id)
-        |> Repo.update_all(set: [display_order: index])
+    ordered_ids =
+      Enum.map(ordered_ids, fn
+        id when is_integer(id) -> id
+        id when is_binary(id) -> String.to_integer(id)
       end)
-    end)
+
+    # Single bulk UPDATE using unnest join — avoids N+1 queries
+    orders = Enum.to_list(0..(length(ordered_ids) - 1))
+
+    from(i in CarouselImage,
+      join: v in fragment("SELECT * FROM unnest(?::int[], ?::int[]) AS v(id, ord)", ^ordered_ids, ^orders),
+      on: i.id == v.id,
+      update: [set: [display_order: v.ord, updated_at: ^DateTime.utc_now()]]
+    )
+    |> Repo.update_all([])
 
     refresh_and_broadcast()
     :ok

--- a/lib/lanpartyseating/repositories/carousel_image_repo.ex
+++ b/lib/lanpartyseating/repositories/carousel_image_repo.ex
@@ -1,0 +1,53 @@
+defmodule Lanpartyseating.CarouselImage do
+  @moduledoc """
+  Schema for game cover images displayed in the carousel on the display page.
+  Images are stored as binary blobs in the database and cached in ETS at runtime.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @allowed_content_types ~w(image/jpeg image/png image/webp)
+  @max_file_size 2 * 1024 * 1024
+
+  schema "carousel_images" do
+    field :title, :string
+    field :image_data, :binary
+    field :content_type, :string
+    field :display_order, :integer, default: 0
+    field :enabled, :boolean, default: true
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc "Changeset for creating a new carousel image from an upload."
+  def changeset(image, attrs) do
+    image
+    |> cast(attrs, [:title, :image_data, :content_type, :display_order, :enabled])
+    |> validate_required([:image_data, :content_type])
+    |> validate_inclusion(:content_type, @allowed_content_types, message: "must be JPEG, PNG, or WebP")
+    |> validate_number(:display_order, greater_than_or_equal_to: 0)
+    |> validate_length(:title, max: 255)
+    |> validate_file_size()
+  end
+
+  @doc "Changeset for updating metadata (title, order, enabled) without replacing image data."
+  def metadata_changeset(image, attrs) do
+    image
+    |> cast(attrs, [:title, :display_order, :enabled])
+    |> validate_number(:display_order, greater_than_or_equal_to: 0)
+    |> validate_length(:title, max: 255)
+  end
+
+  defp validate_file_size(changeset) do
+    validate_change(changeset, :image_data, fn :image_data, data ->
+      if byte_size(data) > @max_file_size do
+        [image_data: "must be less than 2MB"]
+      else
+        []
+      end
+    end)
+  end
+
+  def allowed_content_types, do: @allowed_content_types
+  def max_file_size, do: @max_file_size
+end

--- a/lib/lanpartyseating_web/components/icons.ex
+++ b/lib/lanpartyseating_web/components/icons.ex
@@ -297,4 +297,42 @@ defmodule LanpartyseatingWeb.Components.Icons do
     </svg>
     """
   end
+
+  attr :class, :string, default: "w-5 h-5"
+
+  def photo(assigns) do
+    ~H"""
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class={@class}>
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Zm14.25-12a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"
+      />
+    </svg>
+    """
+  end
+
+  attr :class, :string, default: "w-5 h-5"
+
+  def bars_3(assigns) do
+    ~H"""
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class={@class}>
+      <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+    </svg>
+    """
+  end
+
+  attr :class, :string, default: "w-5 h-5"
+
+  def trash(assigns) do
+    ~H"""
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class={@class}>
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+      />
+    </svg>
+    """
+  end
 end

--- a/lib/lanpartyseating_web/components/settings_nav.ex
+++ b/lib/lanpartyseating_web/components/settings_nav.ex
@@ -12,7 +12,7 @@ defmodule LanpartyseatingWeb.Components.SettingsNav do
 
   ## Attributes
 
-    * `:current_page` - The current page atom (:seating, :reservations, :users, :badges, :scanners)
+    * `:current_page` - The current page atom (:seating, :reservations, :carousel, :users, :badges, :scanners)
     * `:is_user_auth` - Whether the user is authenticated via user login (not badge)
   """
   attr :current_page, :atom, required: true
@@ -44,6 +44,17 @@ defmodule LanpartyseatingWeb.Components.SettingsNav do
         >
           <Icons.clock class="w-5 h-5" />
           <span>Reservations</span>
+        </.link>
+      </li>
+
+      <%!-- Carousel - available to all authenticated users --%>
+      <li>
+        <.link
+          navigate={~p"/settings/carousel"}
+          class={["flex items-center gap-3", @current_page == :carousel && "active"]}
+        >
+          <Icons.photo class="w-5 h-5" />
+          <span>Game Carousel</span>
         </.link>
       </li>
 

--- a/lib/lanpartyseating_web/controllers/carousel_image_controller.ex
+++ b/lib/lanpartyseating_web/controllers/carousel_image_controller.ex
@@ -8,15 +8,21 @@ defmodule LanpartyseatingWeb.CarouselImageController do
   alias Lanpartyseating.CarouselLogic
 
   def show(conn, %{"id" => id}) do
-    case CarouselLogic.get_image_data(String.to_integer(id)) do
-      {content_type, data} ->
-        conn
-        |> put_resp_content_type(content_type)
-        |> put_resp_header("cache-control", "public, max-age=3600")
-        |> send_resp(200, data)
+    case Integer.parse(id) do
+      {int_id, ""} ->
+        case CarouselLogic.get_image_data(int_id) do
+          {content_type, data} ->
+            conn
+            |> put_resp_content_type(content_type)
+            |> put_resp_header("cache-control", "public, max-age=300")
+            |> send_resp(200, data)
 
-      nil ->
-        send_resp(conn, 404, "Not found")
+          nil ->
+            send_resp(conn, 404, "Not found")
+        end
+
+      _ ->
+        send_resp(conn, 400, "Invalid ID")
     end
   end
 end

--- a/lib/lanpartyseating_web/controllers/carousel_image_controller.ex
+++ b/lib/lanpartyseating_web/controllers/carousel_image_controller.ex
@@ -1,0 +1,22 @@
+defmodule LanpartyseatingWeb.CarouselImageController do
+  @moduledoc """
+  Serves carousel image binaries from the in-memory cache.
+  Public endpoint — no authentication required.
+  """
+  use LanpartyseatingWeb, :controller
+
+  alias Lanpartyseating.CarouselLogic
+
+  def show(conn, %{"id" => id}) do
+    case CarouselLogic.get_image_data(String.to_integer(id)) do
+      {content_type, data} ->
+        conn
+        |> put_resp_content_type(content_type)
+        |> put_resp_header("cache-control", "public, max-age=3600")
+        |> send_resp(200, data)
+
+      nil ->
+        send_resp(conn, 404, "Not found")
+    end
+  end
+end

--- a/lib/lanpartyseating_web/live/display_live.ex
+++ b/lib/lanpartyseating_web/live/display_live.ex
@@ -218,7 +218,7 @@ defmodule LanpartyseatingWeb.DisplayLive do
                 if (this.total > 1) {
                   this.intervalId = setInterval(() => {
                     this.currentIndex = (this.currentIndex + 1) % this.total;
-                  }, 5000);
+                  }, 2000);
                 }
               },
               destroy() {
@@ -226,7 +226,7 @@ defmodule LanpartyseatingWeb.DisplayLive do
               }
             }"}
             @mouseenter="if (intervalId) { clearInterval(intervalId); intervalId = null; }"
-            @mouseleave="if (total > 1) { intervalId = setInterval(() => { currentIndex = (currentIndex + 1) % total; }, 5000); }"
+            @mouseleave="if (total > 1) { intervalId = setInterval(() => { currentIndex = (currentIndex + 1) % total; }, 2000); }"
           >
             <%!-- Slides area — takes remaining space after dots --%>
             <div class="relative flex-1 min-h-0">

--- a/lib/lanpartyseating_web/live/display_live.ex
+++ b/lib/lanpartyseating_web/live/display_live.ex
@@ -4,6 +4,7 @@ defmodule LanpartyseatingWeb.DisplayLive do
   alias Lanpartyseating.TournamentsLogic
   alias Lanpartyseating.SettingsLogic
   alias Lanpartyseating.StationLogic
+  alias Lanpartyseating.CarouselLogic
 
   defp assign_stations(socket, station_list) do
     {stations, {columns, rows}} = StationLogic.stations_by_xy(station_list)
@@ -40,7 +41,10 @@ defmodule LanpartyseatingWeb.DisplayLive do
     if connected?(socket) do
       Phoenix.PubSub.subscribe(PubSub, "station_update")
       Phoenix.PubSub.subscribe(PubSub, "tournament_update")
+      Phoenix.PubSub.subscribe(PubSub, "carousel_update")
     end
+
+    carousel_images = CarouselLogic.list_images()
 
     socket =
       socket
@@ -48,12 +52,17 @@ defmodule LanpartyseatingWeb.DisplayLive do
       |> assign(:rowpad, settings.row_padding)
       |> assign_stations(station_list)
       |> assign(:tournaments, tournaments)
+      |> assign(:carousel_images, carousel_images)
 
     {:ok, socket}
   end
 
   def handle_info({:tournaments, tournaments}, socket) do
     {:noreply, assign(socket, :tournaments, tournaments)}
+  end
+
+  def handle_info({:carousel, :updated}, socket) do
+    {:noreply, assign(socket, :carousel_images, CarouselLogic.list_images())}
   end
 
   def handle_info({:stations, station_list}, socket) do
@@ -71,8 +80,8 @@ defmodule LanpartyseatingWeb.DisplayLive do
 
   def render(assigns) do
     ~H"""
-    <div class="flex flex-row">
-      <div class="flex flex-col w-2/3 pr-5">
+    <div class="flex flex-row h-[calc(100vh-7rem)]">
+      <div class="flex flex-col w-2/3 pr-5 overflow-y-auto">
         <%!-- STATION MAP --%>
         <div class="flex items-center justify-between mb-2">
           <h1 class="text-3xl font-bold">Stations</h1>
@@ -194,46 +203,76 @@ defmodule LanpartyseatingWeb.DisplayLive do
           <p class="text-base-content/50 py-4">No upcoming tournaments / Aucun tournoi à venir</p>
         <% end %>
       </div>
-      <div class="flex flex-col grow pl-4 border-l border-base-300">
-        <h1 class="text-3xl font-bold mb-4">Rules and Information</h1>
-        <ul class="list-disc pl-5 space-y-2 text-lg">
-          <li>
-            <b class="text-warning">No spectators</b>. You need a reservation to be inside and to seat at a station
-          </li>
-          <li>
-            <b class="text-warning">No free accounts</b>. You need to your own account to play games
-          </li>
-          <li><b class="text-warning">No OSU</b> for music copyright reasons</li>
-          <li>
-            <b class="text-warning">Tournaments</b>:
-            <ul class="list-disc pl-5 mt-1 space-y-1 text-base">
-              <li>Complete teams will be prioritized</li>
-              <li>Register your team or as a solo player at the info desk located at the room's entrance</li>
-              <li>All tournaments are single elimination with prizes for the winning team</li>
-            </ul>
-          </li>
-        </ul>
+      <div class="flex flex-col grow pl-4 border-l border-base-300 overflow-hidden min-h-0">
+        <h1 class="text-3xl font-bold mb-4">Games Available / Jeux disponibles</h1>
 
-        <h1 class="text-3xl font-bold mt-8 mb-4">Règlements et informations</h1>
-        <ul class="list-disc pl-5 space-y-2 text-lg">
-          <li>
-            <b class="text-warning">Pas de spectateurs</b>. Il est nécessaire de faire une réservation avant d'entrer dans la zone et de s'asseoir
-          </li>
-          <li>
-            <b class="text-warning">Pas de comptes de jeu gratuit</b>. Vous devez posséder des comptes pour jouer aux jeux
-          </li>
-          <li>
-            <b class="text-warning">Pas de OSU</b> pour des raisons de droits d'auteur
-          </li>
-          <li>
-            <b class="text-warning">Tournois</b>:
-            <ul class="list-disc pl-5 mt-1 space-y-1 text-base">
-              <li>Les équipes complètes seront priorisées</li>
-              <li>Enregistrez-vous ou votre équipe au bureau d'information à l'entrée de la salle</li>
-              <li>Tous les tournois sont à élimination simple avec des prix pour l'équipe gagnante</li>
-            </ul>
-          </li>
-        </ul>
+        <%= if @carousel_images != [] do %>
+          <div
+            id="game-carousel"
+            class="flex-1 flex flex-col min-h-0"
+            x-data={"{
+              currentIndex: 0,
+              total: #{length(@carousel_images)},
+              intervalId: null,
+              init() {
+                if (this.total > 1) {
+                  this.intervalId = setInterval(() => {
+                    this.currentIndex = (this.currentIndex + 1) % this.total;
+                  }, 5000);
+                }
+              },
+              destroy() {
+                if (this.intervalId) clearInterval(this.intervalId);
+              }
+            }"}
+            @mouseenter="if (intervalId) { clearInterval(intervalId); intervalId = null; }"
+            @mouseleave="if (total > 1) { intervalId = setInterval(() => { currentIndex = (currentIndex + 1) % total; }, 5000); }"
+          >
+            <%!-- Slides area — takes remaining space after dots --%>
+            <div class="relative flex-1 min-h-0">
+              <%= for {image, index} <- Enum.with_index(@carousel_images) do %>
+                <div
+                  class="absolute inset-0 flex flex-col items-center transition-opacity duration-700"
+                  x-show={"currentIndex === #{index}"}
+                  x-transition:enter="transition ease-out duration-700"
+                  x-transition:enter-start="opacity-0"
+                  x-transition:enter-end="opacity-100"
+                  x-transition:leave="transition ease-in duration-500"
+                  x-transition:leave-start="opacity-100"
+                  x-transition:leave-end="opacity-0"
+                >
+                  <div class="flex-1 min-h-0 flex items-center justify-center w-full">
+                    <img
+                      src={~p"/carousel/images/#{image.id}"}
+                      alt={image.title || "Game cover"}
+                      class="max-w-full max-h-full object-contain rounded-lg shadow-lg"
+                    />
+                  </div>
+                  <%= if image.title do %>
+                    <p class="text-xl font-semibold mt-2 text-center flex-shrink-0">{image.title}</p>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+
+            <%!-- Dot indicators — in flow below the slides --%>
+            <%= if length(@carousel_images) > 1 do %>
+              <div class="flex justify-center gap-2 py-2 flex-shrink-0">
+                <%= for {_image, index} <- Enum.with_index(@carousel_images) do %>
+                  <button
+                    class="w-3 h-3 rounded-full transition-colors"
+                    x-bind:class={"currentIndex === #{index} ? 'bg-primary' : 'bg-base-content/30'"}
+                    x-on:click={"currentIndex = #{index}"}
+                  />
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="flex-1 flex items-center justify-center text-base-content/50">
+            <p class="text-lg">No games configured / Aucun jeu configur&eacute;</p>
+          </div>
+        <% end %>
       </div>
     </div>
     """

--- a/lib/lanpartyseating_web/live/settings/carousel_live.ex
+++ b/lib/lanpartyseating_web/live/settings/carousel_live.ex
@@ -200,7 +200,7 @@ defmodule LanpartyseatingWeb.Settings.CarouselLive do
           <label for="settings-drawer" class="btn btn-square btn-ghost">
             <Icons.menu />
           </label>
-          <span class="text-lg font-bold">Carousel</span>
+          <span class="text-lg font-bold">Game Carousel</span>
         </div>
 
         <%!-- Main content area --%>

--- a/lib/lanpartyseating_web/live/settings/carousel_live.ex
+++ b/lib/lanpartyseating_web/live/settings/carousel_live.ex
@@ -1,0 +1,403 @@
+defmodule LanpartyseatingWeb.Settings.CarouselLive do
+  @moduledoc """
+  Settings page for managing the game cover carousel displayed on the public display page.
+  Supports image upload, title editing, enable/disable toggle, reordering, and deletion.
+  Requires full user authentication (not badge auth).
+  """
+  use LanpartyseatingWeb, :live_view
+
+  alias Lanpartyseating.CarouselLogic
+  alias LanpartyseatingWeb.Components.SettingsNav
+
+  # ============================================================================
+  # Mount & Handle Params
+  # ============================================================================
+
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Lanpartyseating.PubSub, "carousel_update")
+    end
+
+    socket =
+      socket
+      |> allow_upload(:carousel_image,
+        accept: ~w(.jpg .jpeg .png .webp),
+        max_entries: 1,
+        max_file_size: 2_000_000
+      )
+      |> assign(:upload_error, nil)
+      |> assign(:title_form, %{"title" => ""})
+      |> assign(:editing_image, nil)
+      |> assign(:edit_title, "")
+      |> assign(:delete_confirm_id, nil)
+
+    {:ok, socket}
+  end
+
+  def handle_params(_params, _uri, socket) do
+    if socket.assigns.is_user_auth do
+      {:noreply, load_data(socket)}
+    else
+      {:noreply,
+       socket
+       |> put_flash(:error, "Full admin access required")
+       |> push_navigate(to: ~p"/settings/seating", replace: true)}
+    end
+  end
+
+  defp load_data(socket) do
+    assign(socket, :images, CarouselLogic.list_all_images())
+  end
+
+  # ============================================================================
+  # Event Handlers
+  # ============================================================================
+
+  def handle_event("validate_upload", _params, socket) do
+    {:noreply, assign(socket, :upload_error, nil)}
+  end
+
+  def handle_event("change_title", %{"title" => title}, socket) do
+    {:noreply, assign(socket, :title_form, %{"title" => title})}
+  end
+
+  def handle_event("upload_image", %{"title" => title}, socket) do
+    case uploaded_entries(socket, :carousel_image) do
+      {[entry], []} ->
+        result =
+          consume_uploaded_entry(socket, entry, fn %{path: path} ->
+            image_data = File.read!(path)
+            {:ok, {image_data, entry.client_type}}
+          end)
+
+        case result do
+          {image_data, content_type} ->
+            attrs = %{
+              image_data: image_data,
+              content_type: content_type,
+              title: if(title == "", do: nil, else: title),
+            }
+
+            case CarouselLogic.create_image(attrs) do
+              {:ok, _image} ->
+                {:noreply,
+                 socket
+                 |> assign(:title_form, %{"title" => ""})
+                 |> assign(:upload_error, nil)
+                 |> put_flash(:info, "Image uploaded")
+                 |> load_data()}
+
+              {:error, _changeset} ->
+                {:noreply,
+                 socket
+                 |> assign(:upload_error, "Failed to save image")
+                 |> put_flash(:error, "Failed to save image")}
+            end
+
+          _ ->
+            {:noreply, assign(socket, :upload_error, "Upload failed")}
+        end
+
+      {[], [_error | _]} ->
+        {:noreply, assign(socket, :upload_error, "Invalid file. Use JPEG, PNG, or WebP under 2MB.")}
+
+      {[], []} ->
+        {:noreply, assign(socket, :upload_error, "Please select an image file")}
+    end
+  end
+
+  def handle_event("toggle_enabled", %{"id" => id_str}, socket) do
+    id = String.to_integer(id_str)
+    image = Enum.find(socket.assigns.images, &(&1.id == id))
+
+    if image do
+      CarouselLogic.update_image(id, %{enabled: !image.enabled})
+      {:noreply, load_data(socket)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("reorder", %{"ids" => ordered_ids}, socket) do
+    CarouselLogic.reorder_images(ordered_ids)
+    {:noreply, load_data(socket)}
+  end
+
+  def handle_event("start_edit", %{"id" => id_str}, socket) do
+    id = String.to_integer(id_str)
+    image = Enum.find(socket.assigns.images, &(&1.id == id))
+
+    {:noreply,
+     socket
+     |> assign(:editing_image, id)
+     |> assign(:edit_title, image[:title] || "")}
+  end
+
+  def handle_event("change_edit_title", %{"title" => title}, socket) do
+    {:noreply, assign(socket, :edit_title, title)}
+  end
+
+  def handle_event("save_edit", _params, socket) do
+    id = socket.assigns.editing_image
+    title = socket.assigns.edit_title
+    title = if title == "", do: nil, else: title
+
+    CarouselLogic.update_image(id, %{title: title})
+
+    {:noreply,
+     socket
+     |> assign(:editing_image, nil)
+     |> assign(:edit_title, "")
+     |> load_data()}
+  end
+
+  def handle_event("cancel_edit", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:editing_image, nil)
+     |> assign(:edit_title, "")}
+  end
+
+  def handle_event("confirm_delete", %{"id" => id_str}, socket) do
+    {:noreply, assign(socket, :delete_confirm_id, String.to_integer(id_str))}
+  end
+
+  def handle_event("cancel_delete", _params, socket) do
+    {:noreply, assign(socket, :delete_confirm_id, nil)}
+  end
+
+  def handle_event("delete_image", %{"id" => id_str}, socket) do
+    id = String.to_integer(id_str)
+    CarouselLogic.delete_image(id)
+
+    {:noreply,
+     socket
+     |> assign(:delete_confirm_id, nil)
+     |> put_flash(:info, "Image deleted")
+     |> load_data()}
+  end
+
+  # ============================================================================
+  # PubSub Handlers
+  # ============================================================================
+
+  def handle_info({:carousel, :updated}, socket) do
+    {:noreply, load_data(socket)}
+  end
+
+  # ============================================================================
+  # Render
+  # ============================================================================
+
+  def render(assigns) do
+    ~H"""
+    <div class="drawer lg:drawer-open">
+      <input id="settings-drawer" type="checkbox" class="drawer-toggle" />
+
+      <div class="drawer-content">
+        <%!-- Mobile header with hamburger --%>
+        <div class="lg:hidden navbar bg-base-200 border-b border-base-300">
+          <label for="settings-drawer" class="btn btn-square btn-ghost">
+            <Icons.menu />
+          </label>
+          <span class="text-lg font-bold">Carousel</span>
+        </div>
+
+        <%!-- Main content area --%>
+        <div class="p-4 lg:p-6">
+          <.carousel_content {assigns} />
+        </div>
+      </div>
+
+      <div class="drawer-side z-40">
+        <label for="settings-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
+        <SettingsNav.settings_nav current_page={:carousel} is_user_auth={@is_user_auth} />
+      </div>
+    </div>
+    """
+  end
+
+  defp carousel_content(assigns) do
+    ~H"""
+    <div class="max-w-4xl">
+      <.page_header
+        title="Game Carousel"
+        subtitle="Manage game cover images shown on the display page"
+      />
+
+      <%!-- Upload Section --%>
+      <.admin_section title="Upload New Image">
+        <form id="carousel-upload-form" phx-submit="upload_image" phx-change="validate_upload" class="space-y-4">
+          <div class="flex flex-col sm:flex-row gap-4 items-start">
+            <div class="flex-1">
+              <label class="label">
+                <span class="label-text font-medium">Game Title (optional)</span>
+              </label>
+              <input
+                type="text"
+                name="title"
+                value={@title_form["title"]}
+                placeholder="e.g. League of Legends"
+                class="input input-bordered w-full"
+                phx-change="change_title"
+                phx-debounce="300"
+              />
+            </div>
+            <div class="flex-1">
+              <label class="label">
+                <span class="label-text font-medium">Image File</span>
+              </label>
+              <.live_file_input upload={@uploads.carousel_image} class="file-input file-input-bordered w-full" />
+              <p class="text-xs text-base-content/50 mt-1">JPEG, PNG, or WebP. Max 2MB.</p>
+            </div>
+          </div>
+
+          <%= if @upload_error do %>
+            <div class="alert alert-error text-sm">
+              <Icons.exclamation_triangle class="w-4 h-4" />
+              <span>{@upload_error}</span>
+            </div>
+          <% end %>
+
+          <%!-- Upload preview --%>
+          <%= for entry <- @uploads.carousel_image.entries do %>
+            <div class="flex items-center gap-4 p-3 bg-base-200 rounded-lg">
+              <.live_img_preview entry={entry} class="w-14 h-20 object-cover rounded" />
+              <div class="flex-1">
+                <p class="text-sm font-medium">{entry.client_name}</p>
+                <p class="text-xs text-base-content/50">{Float.round(entry.client_size / 1_000_000, 2)} MB</p>
+              </div>
+              <progress class="progress progress-primary w-24" value={entry.progress} max="100" />
+            </div>
+
+            <%= for err <- upload_errors(@uploads.carousel_image, entry) do %>
+              <div class="alert alert-error text-sm">
+                <span>{upload_error_to_string(err)}</span>
+              </div>
+            <% end %>
+          <% end %>
+
+          <div class="flex justify-end">
+            <button type="submit" class="btn btn-primary" disabled={@uploads.carousel_image.entries == []}>
+              <Icons.arrow_up_tray class="w-4 h-4" /> Upload
+            </button>
+          </div>
+        </form>
+      </.admin_section>
+
+      <%!-- Image List Section --%>
+      <.admin_section title={"Carousel Images (#{length(@images)})"}>
+        <%= if @images == [] do %>
+          <div class="text-center py-12 text-base-content/50">
+            <Icons.photo class="w-12 h-12 mx-auto mb-3 opacity-50" />
+            <p class="text-lg">No images yet</p>
+            <p class="text-sm">Upload game covers above to get started</p>
+          </div>
+        <% else %>
+          <div id="carousel-image-list" phx-hook="SortableListHook" class="space-y-3">
+            <%= for image <- @images do %>
+              <div
+                data-id={image.id}
+                class={[
+                  "flex items-center gap-4 p-3 rounded-lg border",
+                  if(image.enabled, do: "border-base-300 bg-base-100", else: "border-base-300 bg-base-200 opacity-60")
+                ]}
+              >
+                <%!-- Thumbnail --%>
+                <img
+                  src={~p"/carousel/images/#{image.id}"}
+                  class="w-14 h-20 object-cover rounded flex-shrink-0"
+                  alt={image.title || "Carousel image"}
+                />
+
+                <%!-- Title / Edit --%>
+                <div class="flex-1 min-w-0">
+                  <%= if @editing_image == image.id do %>
+                    <form phx-submit="save_edit" class="flex gap-2">
+                      <input
+                        type="text"
+                        name="title"
+                        value={@edit_title}
+                        phx-change="change_edit_title"
+                        phx-debounce="200"
+                        class="input input-bordered input-sm flex-1"
+                        placeholder="Game title (optional)"
+                        autofocus
+                      />
+                      <button type="submit" class="btn btn-sm btn-success">
+                        <Icons.check class="w-4 h-4" />
+                      </button>
+                      <button type="button" class="btn btn-sm btn-ghost" phx-click="cancel_edit">
+                        <Icons.x class="w-4 h-4" />
+                      </button>
+                    </form>
+                  <% else %>
+                    <p
+                      class="font-medium truncate cursor-pointer hover:text-primary"
+                      phx-click="start_edit"
+                      phx-value-id={image.id}
+                      title="Click to edit title"
+                    >
+                      {image.title || "(no title)"}
+                    </p>
+                    <p class="text-xs text-base-content/50">
+                      {image.content_type} &middot; Order: {image.display_order}
+                    </p>
+                  <% end %>
+                </div>
+
+                <%!-- Controls --%>
+                <div class="flex items-center gap-1 flex-shrink-0">
+                  <%!-- Drag handle for reordering --%>
+                  <div data-drag-handle draggable="true" class="cursor-grab active:cursor-grabbing px-1" title="Drag to reorder">
+                    <Icons.bars_3 class="w-5 h-5 text-base-content/40" />
+                  </div>
+
+                  <%!-- Toggle enabled --%>
+                  <label class="label cursor-pointer px-2" title={if(image.enabled, do: "Disable", else: "Enable")}>
+                    <input
+                      type="checkbox"
+                      class="toggle toggle-sm toggle-success"
+                      checked={image.enabled}
+                      phx-click="toggle_enabled"
+                      phx-value-id={image.id}
+                    />
+                  </label>
+
+                  <%!-- Delete --%>
+                  <%= if @delete_confirm_id == image.id do %>
+                    <button
+                      class="btn btn-sm btn-error"
+                      phx-click="delete_image"
+                      phx-value-id={image.id}
+                    >
+                      Confirm
+                    </button>
+                    <button class="btn btn-sm btn-ghost" phx-click="cancel_delete">
+                      Cancel
+                    </button>
+                  <% else %>
+                    <button
+                      class="btn btn-sm btn-ghost text-error"
+                      phx-click="confirm_delete"
+                      phx-value-id={image.id}
+                      title="Delete image"
+                    >
+                      <Icons.trash class="w-4 h-4" />
+                    </button>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </.admin_section>
+    </div>
+    """
+  end
+
+  defp upload_error_to_string(:too_large), do: "File is too large (max 2MB)"
+  defp upload_error_to_string(:not_accepted), do: "Invalid file type. Use JPEG, PNG, or WebP."
+  defp upload_error_to_string(:too_many_files), do: "Only one file at a time"
+  defp upload_error_to_string(err), do: "Upload error: #{inspect(err)}"
+end

--- a/lib/lanpartyseating_web/router.ex
+++ b/lib/lanpartyseating_web/router.ex
@@ -40,6 +40,9 @@ defmodule LanpartyseatingWeb.Router do
   scope "/", LanpartyseatingWeb do
     pipe_through(:browser)
 
+    # Carousel image serving (plain controller, no LiveView)
+    get "/carousel/images/:id", CarouselImageController, :show
+
     live_session :public,
       on_mount: [
         {LanpartyseatingWeb.UserAuth, :mount_current_scope},
@@ -89,6 +92,7 @@ defmodule LanpartyseatingWeb.Router do
       live("/settings/reservations", Settings.ReservationsLive, :reservations)
       live("/settings/users", Settings.UsersLive, :users)
       live("/settings/badges", Settings.BadgesLive, :badges)
+      live("/settings/carousel", Settings.CarouselLive, :carousel)
       live("/settings/scanners", Settings.ScannersLive, :scanners)
     end
   end

--- a/priv/repo/migrations/20260310044435_create_carousel_images.exs
+++ b/priv/repo/migrations/20260310044435_create_carousel_images.exs
@@ -1,0 +1,17 @@
+defmodule Lanpartyseating.Repo.Migrations.CreateCarouselImages do
+  use Ecto.Migration
+
+  def change do
+    create table(:carousel_images) do
+      add :title, :string, size: 255
+      add :image_data, :binary, null: false
+      add :content_type, :string, size: 64, null: false
+      add :display_order, :integer, null: false, default: 0
+      add :enabled, :boolean, null: false, default: true
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:carousel_images, [:display_order])
+  end
+end


### PR DESCRIPTION
This PR replaces the hard-coded rules (to be moved to digital signage screen) with a carousel of available games for the public to see.

- Added new admin section with CRUD interface to upload, delete, re-order, en/disable images to be displayed in the carousel.
- Tested with images sourced from https://www.steamgriddb.com, 600x900 size is a perfect aspect ratio for the display page.
- Images are saved in DB table as binary blobs, and loaded into an ETS table at startup to avoid loading the DB when fetching them for display.

Demo: https://cornish-rex.s3.us-west-000.backblazeb2.com/Screen+Recording+2026-03-10+at+23.28.46.mov

Closes #84, Closes #102 