### PR TITLE
Fix scanner LiveView production crash

### DIFF
--- a/lib/lanpartyseating_web/live/settings/scanners_live.ex
+++ b/lib/lanpartyseating_web/live/settings/scanners_live.ex
@@ -556,13 +556,6 @@ defmodule LanpartyseatingWeb.Settings.ScannersLive do
               <p class="mt-2">
                 Include the scanner token in the Authorization header: <code>Authorization: Bearer lpss_...</code>
               </p>
-              <%= if Mix.env() == :dev do %>
-                <p class="mt-2">
-                  <.link href="/api/docs" target="_blank" class="link link-primary">
-                    View API Documentation (Swagger UI)
-                  </.link>
-                </p>
-              <% end %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Remove the production-unsafe Mix.env conditional from the scanner settings LiveView
- Remove the dev-only Swagger UI link, which is not routed in production

## Verification
- mix compile --warnings-as-errors
- mix test test/lanpartyseating_web/live/settings/scanners_live_test.exs (blocked: PostgreSQL was not running on localhost:5021)