### PR TITLE
Enable manual Docker image workflow dispatch

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,6 +1,7 @@
 name: "Docker Image"
 on:
   push:
+  workflow_dispatch:
 env:
   REGISTRY: ghcr.io
 jobs:


### PR DESCRIPTION
Add workflow_dispatch to the Docker image workflow so production images can be rebuilt manually when a push-triggered run is missed.